### PR TITLE
fix pager view ios crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "react-native-expo-crypto": "^2.1.4",
         "react-native-gesture-handler": "~2.1.0",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",
+        "react-native-pager-view": "^5.4.15",
         "react-native-qrcode-svg": "^6.1.2",
         "react-native-safe-area-context": "3.3.2",
         "react-native-screens": "~3.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8014,10 +8014,15 @@ react-native-modal@^13.0.1:
     prop-types "^15.6.2"
     react-native-animatable "1.3.3"
 
-react-native-pager-view@5.4.9, react-native-pager-view@^5.4.15:
+react-native-pager-view@5.4.9:
   version "5.4.9"
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.9.tgz#c0d40847cfeda5a4e729b53271b0ee0fedff3eb5"
   integrity sha512-D6tzxpwMGdl6CXgtskGWhKRc5cJakCazESRGt7PkqnpyiH3N35ft1KmR82pCSQetAFlytFiToeu3a/dG5CELvA==
+
+react-native-pager-view@^5.4.15:
+  version "5.4.25"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.25.tgz#cd639d5387a7f3d5581b55a33c5faa1cbc200f97"
+  integrity sha512-3drrYwaLat2fYszymZe3nHMPASJ4aJMaxiejfA1V5SK3OygYmdtmV2u5prX7TnjueJzGSyyaCYEr2JlrRt4YPg==
 
 react-native-qrcode-svg@^6.1.2:
   version "6.1.2"


### PR DESCRIPTION
# Fix PagerView ios crash

## Issues

closes #77 

## Changes

* Install react-native-view-pager explicitly, otherwise ios doesn't find RNCViewPager