### PR TITLE
Change tab indicator color based on selectedWallet

### DIFF
--- a/src/module/main/component/navigation/MainTabs/MainTabs.tsx
+++ b/src/module/main/component/navigation/MainTabs/MainTabs.tsx
@@ -1,20 +1,20 @@
-import { Col, useTheme, TabPanel, Tabs } from "@peersyst/react-native-components";
+import { Col, TabPanel, Tabs } from "@peersyst/react-native-components";
 import MainTab from "module/main/component/navigation/MainTabs/MainTab/MainTab";
 import { useState } from "react";
 import { TabGroup } from "./MainTabs.styles";
 import { MainTabsType as MainTabsProps } from "./MainTabs.types";
 import { LinearGradient } from "expo-linear-gradient";
+import useWalletGradient from "module/wallet/hook/useWalletGradient";
 
 const MainTabs = ({ tabs }: MainTabsProps): JSX.Element => {
     const [index, setIndex] = useState(0);
-
-    const { palette } = useTheme();
+    const [startColor, endColor] = useWalletGradient();
 
     return (
         <Tabs gap={0} index={index} onIndexChange={setIndex} style={{ flex: 1 }}>
             <TabGroup
                 renderIndicator={true}
-                indicator={<LinearGradient start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} colors={palette.gradient.blueTurquoise} />}
+                indicator={<LinearGradient start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} colors={[startColor, endColor]} />}
             >
                 {tabs.map(({ title }, index) => {
                     return (

--- a/src/module/main/component/navigation/MainTabs/MainTabs.tsx
+++ b/src/module/main/component/navigation/MainTabs/MainTabs.tsx
@@ -8,13 +8,13 @@ import useWalletGradient from "module/wallet/hook/useWalletGradient";
 
 const MainTabs = ({ tabs }: MainTabsProps): JSX.Element => {
     const [index, setIndex] = useState(0);
-    const [startColor, endColor] = useWalletGradient();
+    const gradientColor = useWalletGradient();
 
     return (
         <Tabs gap={0} index={index} onIndexChange={setIndex} style={{ flex: 1 }}>
             <TabGroup
                 renderIndicator={true}
-                indicator={<LinearGradient start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} colors={[startColor, endColor]} />}
+                indicator={<LinearGradient start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} colors={gradientColor} />}
             >
                 {tabs.map(({ title }, index) => {
                     return (

--- a/test/__mocks__/common/wallet/index.tsx
+++ b/test/__mocks__/common/wallet/index.tsx
@@ -11,3 +11,4 @@ export * from "./useGetBalance.mock";
 export * from "./useAssetSelect.mock";
 export * from "./useGetAllAssets.mock";
 export * from "./useNativeTokenConversion.mock";
+export * from "./useWalletGradient.mock";

--- a/test/__mocks__/common/wallet/useWalletGradient.mock.ts
+++ b/test/__mocks__/common/wallet/useWalletGradient.mock.ts
@@ -1,0 +1,12 @@
+import BaseMock from "mocks/common/base.mock";
+import { PaletteGradient } from "config/theme/theme.declarations";
+import * as UseWalletGradient from "module/wallet/hook/useWalletGradient";
+
+export class UseWalletGradientMock extends BaseMock {
+    walletGradient: PaletteGradient;
+    constructor(walletGradient: PaletteGradient = ["#000000", "#FFFFFF"]) {
+        super();
+        this.walletGradient = walletGradient;
+        this.mock = jest.spyOn(UseWalletGradient, "default").mockReturnValue(this.walletGradient);
+    }
+}

--- a/test/unit/src/module/main/component/navigation/MainTabs/MainTabs.spec.tsx
+++ b/test/unit/src/module/main/component/navigation/MainTabs/MainTabs.spec.tsx
@@ -3,8 +3,19 @@ import MainTabs from "module/main/component/navigation/MainTabs/MainTabs";
 import { fireEvent } from "@testing-library/react-native";
 import { MainTabItemType } from "module/main/component/navigation/MainTabs/MainTabs.types";
 import { Typography } from "@peersyst/react-native-components";
+import { UseWalletGradientMock } from "mocks/common";
 
 describe("MainTabs tests", () => {
+    let useWalletGradientMock: UseWalletGradientMock;
+
+    beforeAll(() => {
+        useWalletGradientMock = new UseWalletGradientMock();
+    });
+
+    afterAll(() => {
+        useWalletGradientMock.clear();
+    });
+
     test("Renders correctly", () => {
         const Tabs: MainTabItemType[] = [
             {


### PR DESCRIPTION
# Change tab indicator color based on selectedWallet

## Issues

closes #234 

## Changes

- MainTabs (calling useWalletGradient to get the colors) + test
- useWalletGradient.mock.ts (Created necessary mock for MainTabs test) 
