### PR TITLE
[TA-1151] DeleteKey (details modal + action approval)

### DIFF
--- a/src/locale/locales/en/common.json
+++ b/src/locale/locales/en/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/es/common.json
+++ b/src/locale/locales/es/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Cuenta desconocida",
     "disconnectSuccessfully": "Desconectado satisfactoriamente!",
     "disconnectFailed": "Error al desconectarse. Por favor, inténtelo de nuevo.",
-    "deleteKeyConfirmation": "Estas seguro de querer eliminar las llaves de acceso a {{name}}?"
+    "deleteKeyConfirmation": "Estas seguro de querer eliminar las clave de acceso a {{name}}?",
+    "deleteAccessKey": "Eliminar clave de acceso",
+    "deleteAccessKeyDescription": "Si aprueba esta petición, la siguiente clave de acceso será eliminada de su cuenta."
 }

--- a/src/locale/locales/fr/common.json
+++ b/src/locale/locales/fr/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/id/common.json
+++ b/src/locale/locales/id/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/it/common.json
+++ b/src/locale/locales/it/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/pt/common.json
+++ b/src/locale/locales/pt/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/ru/common.json
+++ b/src/locale/locales/ru/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/uk/common.json
+++ b/src/locale/locales/uk/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/vi/common.json
+++ b/src/locale/locales/vi/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/zh-CN/common.json
+++ b/src/locale/locales/zh-CN/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/locale/locales/zh-TW/common.json
+++ b/src/locale/locales/zh-TW/common.json
@@ -272,5 +272,7 @@
     "unknownAccount": "Unknown account",
     "disconnectSuccessfully": "Disconnected successfully!",
     "disconnectFailed": "Disconnect failed. Please try again.",
-    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?"
+    "deleteKeyConfirmation": "Are your sure you want to remove access keys from {{name}}?",
+    "deleteAccessKey": "Delete access key",
+    "deleteAccessKeyDescription": "By approving this request, the following access key will be deleted from your account."
 }

--- a/src/module/signer/components/display/SignRequestDetails/actions.tsx
+++ b/src/module/signer/components/display/SignRequestDetails/actions.tsx
@@ -3,17 +3,18 @@ import AddKeyDetails from "./actions/AddKeyDetails";
 import { ActionType } from "./actions.types";
 import { ActionDetailsProps } from "./SignRequestDetails.types";
 import FunctionCallDetails from "./actions/FunctionCallDetails";
+import DeleteKeyDetails from "./actions/DeleteKeyDetails";
 
 const Empty = () => null;
 
 export const ActionDetails: Record<ActionType, JSXElementConstructor<ActionDetailsProps>> = {
     AddKey: AddKeyDetails,
     FunctionCall: FunctionCallDetails,
+    DeleteKey: DeleteKeyDetails,
     // TODO: Implement other action types
     Transfer: Empty,
     DeployContract: Empty,
     DeleteAccount: Empty,
-    DeleteKey: Empty,
     Stake: Empty,
     // TODO: Add CreateAccount action type
 };

--- a/src/module/signer/components/display/SignRequestDetails/actions.types.ts
+++ b/src/module/signer/components/display/SignRequestDetails/actions.types.ts
@@ -85,7 +85,7 @@ export interface AddKeyAction {
 /**
  * DeleteKeyAction
  */
-interface DeleteKeyActionParams {
+export interface DeleteKeyActionParams {
     publicKey: string;
 }
 

--- a/src/module/signer/components/display/SignRequestDetails/actions/DeleteKeyDetails.tsx
+++ b/src/module/signer/components/display/SignRequestDetails/actions/DeleteKeyDetails.tsx
@@ -1,0 +1,29 @@
+import { Col, Hash, Typography } from "@peersyst/react-native-components";
+import { ActionDetailsProps } from "../SignRequestDetails.types";
+import { DeleteKeyActionParams } from "../actions.types";
+import Container from "module/common/component/display/Container/Container";
+import { useTranslate } from "module/common/hook/useTranslate";
+
+const DeleteKeyDetails = ({ params }: ActionDetailsProps): JSX.Element => {
+    const { publicKey } = params as DeleteKeyActionParams;
+
+    const translate = useTranslate();
+
+    return (
+        <Col flex={1} gap={24} alignItems="center">
+            <Typography variant="h4Strong" textAlign="center">
+                {translate("deleteAccessKey")}
+            </Typography>
+            <Col flex={1} gap={12}>
+                <Typography variant="body2Regular" textAlign="center">
+                    {translate("deleteAccessKeyDescription")}
+                </Typography>
+                <Container>
+                    <Hash variant="body2Regular" hash={publicKey} length={8} textAlign="center" />
+                </Container>
+            </Col>
+        </Col>
+    );
+};
+
+export default DeleteKeyDetails;

--- a/src/module/signer/queries/useAddKeyAction.ts
+++ b/src/module/signer/queries/useAddKeyAction.ts
@@ -1,30 +1,32 @@
 import useServiceInstance from "module/wallet/hook/useServiceInstance";
-import { useMutation, useQueryClient } from "react-query";
+import { QueryKey } from "react-query";
 import { Action, AddKeyActionParams } from "../components/display/SignRequestDetails/actions.types";
 import Queries from "../../../query/queries";
 
-export default function useAddKeyAction() {
+interface UseAddKeyActionReturn {
+    action: (action: Action) => Promise<string>;
+    queriesToInvalidate: QueryKey[];
+}
+
+export default function useAddKeyAction(): UseAddKeyActionReturn {
     const { serviceInstance, index, network } = useServiceInstance();
-    const queryClient = useQueryClient();
 
-    return useMutation(
-        async (action: Action) => {
-            const params = action.params as AddKeyActionParams;
-            const {
-                publicKey,
-                accessKey: { permission },
-            } = params;
+    const runAddKeyAction = async (action: Action) => {
+        const params = action.params as AddKeyActionParams;
+        const {
+            publicKey,
+            accessKey: { permission },
+        } = params;
 
-            // FunctionCall AccessKey
-            if (typeof permission === "object")
-                await serviceInstance.addAccessKey(publicKey, permission.receiverId, permission.methodNames, permission.allowance);
-            // FullAccessKey
-            else await serviceInstance.addAccessKey(publicKey);
-        },
-        {
-            onSuccess: async () => {
-                await queryClient.invalidateQueries([Queries.GET_ACCOUNT_ACCESS_KEYS, index, network]);
-            },
-        },
-    );
+        // FunctionCall AccessKey
+        if (typeof permission === "object")
+            return await serviceInstance.addAccessKey(publicKey, permission.receiverId, permission.methodNames, permission.allowance);
+        // FullAccessKey
+        else return await serviceInstance.addAccessKey(publicKey);
+    };
+
+    return {
+        action: runAddKeyAction,
+        queriesToInvalidate: [[Queries.ACTIONS, index, network]],
+    };
 }

--- a/src/module/signer/queries/useDeleteAccessKey.ts
+++ b/src/module/signer/queries/useDeleteAccessKey.ts
@@ -1,0 +1,22 @@
+import useServiceInstance from "module/wallet/hook/useServiceInstance";
+import Queries from "query/queries";
+import { useMutation, useQueryClient } from "react-query";
+import { Action, DeleteKeyActionParams } from "../components/display/SignRequestDetails/actions.types";
+
+export default function useDeleteAccessKey() {
+    const { serviceInstance, index, network } = useServiceInstance();
+    const queryClient = useQueryClient();
+
+    return useMutation(
+        async (action: Action) => {
+            const { publicKey } = action.params as DeleteKeyActionParams;
+            await serviceInstance.deleteAccessKey(publicKey);
+        },
+        {
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([Queries.GET_ACCOUNT_ACCESS_KEYS, index, network]);
+                await queryClient.invalidateQueries([Queries.ACTIONS, index, network]);
+            },
+        },
+    );
+}

--- a/src/module/signer/queries/useDeleteAccessKey.ts
+++ b/src/module/signer/queries/useDeleteAccessKey.ts
@@ -1,5 +1,5 @@
 import useServiceInstance from "module/wallet/hook/useServiceInstance";
-import Queries from "query/queries";
+import Queries from "../../../query/queries";
 import { useMutation, useQueryClient } from "react-query";
 import { Action, DeleteKeyActionParams } from "../components/display/SignRequestDetails/actions.types";
 

--- a/src/module/signer/queries/useDeleteAccessKey.ts
+++ b/src/module/signer/queries/useDeleteAccessKey.ts
@@ -1,22 +1,20 @@
 import useServiceInstance from "module/wallet/hook/useServiceInstance";
-import Queries from "../../../query/queries";
-import { useMutation, useQueryClient } from "react-query";
 import { Action, DeleteKeyActionParams } from "../components/display/SignRequestDetails/actions.types";
+import Queries from "../../../query/queries";
 
 export default function useDeleteAccessKey() {
     const { serviceInstance, index, network } = useServiceInstance();
-    const queryClient = useQueryClient();
 
-    return useMutation(
-        async (action: Action) => {
-            const { publicKey } = action.params as DeleteKeyActionParams;
-            await serviceInstance.deleteAccessKey(publicKey);
-        },
-        {
-            onSuccess: async () => {
-                await queryClient.invalidateQueries([Queries.GET_ACCOUNT_ACCESS_KEYS, index, network]);
-                await queryClient.invalidateQueries([Queries.ACTIONS, index, network]);
-            },
-        },
-    );
+    const deleteAccessKey = async (action: Action) => {
+        const { publicKey } = action.params as DeleteKeyActionParams;
+        await serviceInstance.deleteAccessKey(publicKey);
+    };
+
+    return {
+        action: deleteAccessKey,
+        queriesToInvalidate: [
+            [Queries.ACTIONS, index, network],
+            [Queries.GET_ACCOUNT_ACCESS_KEYS, index, network],
+        ],
+    };
 }

--- a/src/module/signer/queries/useSignRequestActions.ts
+++ b/src/module/signer/queries/useSignRequestActions.ts
@@ -3,7 +3,6 @@ import { Action } from "../components/display/SignRequestDetails/actions.types";
 import useAddKeyAction from "./useAddKeyAction";
 import { SignerRequestService } from "module/api/service";
 import useServiceInstance from "module/wallet/hook/useServiceInstance";
-import Queries from "../../../query/queries";
 import useDeleteAccessKey from "./useDeleteAccessKey";
 
 interface UseSignRequestActionsParams {
@@ -12,35 +11,31 @@ interface UseSignRequestActionsParams {
 }
 
 export default function useSignRequestActions() {
-    const { serviceInstance, index, network } = useServiceInstance();
+    const { serviceInstance } = useServiceInstance();
     const queryClient = useQueryClient();
 
-    const addKeyAction = useAddKeyAction();
-    const deleteAccessKeyAction = useDeleteAccessKey();
+    const { action: addKeyAction, queriesToInvalidate: addKeyQueries } = useAddKeyAction();
+    const { action: deleteAccessKey, queriesToInvalidate: deleteAccessKeyQueries } = useDeleteAccessKey();
 
     const signAction = async (action: Action) => {
         switch (action.type) {
             case "AddKey": {
-                await addKeyAction.mutateAsync(action);
+                await addKeyAction(action);
+                await queryClient.invalidateQueries([...addKeyQueries]);
                 break;
             }
             case "DeleteKey": {
-                await deleteAccessKeyAction.mutateAsync(action);
+                await deleteAccessKey(action);
+                await queryClient.invalidateQueries([...deleteAccessKeyQueries]);
+                break;
             }
         }
     };
 
-    return useMutation(
-        async ({ id, actions }: UseSignRequestActionsParams) => {
-            for (const action of actions) {
-                await signAction(action);
-            }
-            return await SignerRequestService.approveSignerRequest(id, { signerAccountId: serviceInstance.getAddress() });
-        },
-        {
-            onSuccess: async () => {
-                await queryClient.invalidateQueries([Queries.ACTIONS, index, network]);
-            },
-        },
-    );
+    return useMutation(async ({ id, actions }: UseSignRequestActionsParams) => {
+        for (const action of actions) {
+            await signAction(action);
+        }
+        return await SignerRequestService.approveSignerRequest(id, { signerAccountId: serviceInstance.getAddress() });
+    });
 }

--- a/src/module/signer/queries/useSignRequestActions.ts
+++ b/src/module/signer/queries/useSignRequestActions.ts
@@ -4,6 +4,7 @@ import useAddKeyAction from "./useAddKeyAction";
 import { SignerRequestService } from "module/api/service";
 import useServiceInstance from "module/wallet/hook/useServiceInstance";
 import Queries from "../../../query/queries";
+import useDeleteAccessKey from "./useDeleteAccessKey";
 
 interface UseSignRequestActionsParams {
     id: string;
@@ -15,11 +16,16 @@ export default function useSignRequestActions() {
     const queryClient = useQueryClient();
 
     const addKeyAction = useAddKeyAction();
+    const deleteAccessKeyAction = useDeleteAccessKey();
 
     const signAction = async (action: Action) => {
         switch (action.type) {
             case "AddKey": {
                 await addKeyAction.mutateAsync(action);
+                break;
+            }
+            case "DeleteKey": {
+                await deleteAccessKeyAction.mutateAsync(action);
             }
         }
     };

--- a/test/unit/src/module/signer/components/display/SignRequestDetails/actions/DeleteKeyDetails.spec.tsx
+++ b/test/unit/src/module/signer/components/display/SignRequestDetails/actions/DeleteKeyDetails.spec.tsx
@@ -1,0 +1,14 @@
+import DeleteKeyDetails from "module/signer/components/display/SignRequestDetails/actions/DeleteKeyDetails";
+import { render, screen, translate } from "test-utils";
+
+describe("DeleteKeyDetails", () => {
+    test("Renders correctly", () => {
+        const mockPublicKey = "publicKey";
+
+        render(<DeleteKeyDetails params={{ publicKey: mockPublicKey }} />);
+
+        expect(screen.getByText(translate("deleteAccessKey"))).toBeDefined();
+        expect(screen.getByText(translate("deleteAccessKeyDescription"))).toBeDefined();
+        expect(screen.getByText(mockPublicKey)).toBeDefined();
+    });
+});


### PR DESCRIPTION
# [TA-1151] DeleteKey (details modal + action approval)

## Tasks

  - [[TA-1151] DeleteKey (details modal + action approval)](https://www.notion.so/DeleteKey-details-modal-action-approval-6c7ec3a8476c437e82ae7610cc0c1bbb?pvs=4)


## Changes

- `DeleteKeyDetails` modal details component
- `useDeleteAccessKey` query
- updated `useSignRequestActions` supporting deleteKey actions
- locale update
- testing
