### PR TITLE
[TA-1238] Fix ActionSlider dots to primary

### DIFF
--- a/src/module/signer/components/display/ActionsSlider/ActionsSlider.styles.ts
+++ b/src/module/signer/components/display/ActionsSlider/ActionsSlider.styles.ts
@@ -1,0 +1,6 @@
+import { PagerView } from "@peersyst/react-native-components";
+import styled from "@peersyst/react-native-styled";
+
+export const ActionsSliderRoot = styled(PagerView)(({ theme }) => ({
+    pagination: { dot: { backgroundColor: theme.palette.overlay["20%"], active: { backgroundColor: theme.palette.primary } } },
+}));

--- a/src/module/signer/components/display/ActionsSlider/ActionsSlider.tsx
+++ b/src/module/signer/components/display/ActionsSlider/ActionsSlider.tsx
@@ -1,7 +1,7 @@
-import { PagerView } from "@peersyst/react-native-components";
 import { Action } from "../SignRequestDetails/actions.types";
 import { ActionDetails } from "../SignRequestDetails/actions";
 import { DAppMetadataDto } from "module/api/service";
+import { ActionsSliderRoot } from "./ActionsSlider.styles";
 
 export interface ActionsSliderProps {
     actions: Action[];
@@ -11,12 +11,12 @@ export interface ActionsSliderProps {
 
 const ActionsSlider = ({ actions, ...rest }: ActionsSliderProps) => {
     return (
-        <PagerView gap={0} showPageIndicator={actions.length > 1} style={{ flex: 1 }}>
+        <ActionsSliderRoot gap={0} showPageIndicator={actions.length > 1} style={{ flex: 1 }}>
             {actions.map(({ type, params }, index) => {
                 const ActionComponent = ActionDetails[type];
                 return <ActionComponent key={index} params={params} {...rest} />;
             })}
-        </PagerView>
+        </ActionsSliderRoot>
     );
 };
 

--- a/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
+++ b/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
@@ -2,6 +2,7 @@ import { Col } from "@peersyst/react-native-components";
 import Button from "module/common/component/input/Button/Button";
 import { useTranslate } from "module/common/hook/useTranslate";
 import { SignatureScaffoldProps } from "./SignatureScaffold.types";
+import SwipeButton from "module/common/component/feedback/SwipeButton/SwipeButton";
 
 const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: SignatureScaffoldProps): JSX.Element => {
     const translate = useTranslate();
@@ -13,9 +14,9 @@ const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: Signatu
                 <Button {...reject} variant="text" onPress={onReject} fullWidth>
                     {translate("reject")}
                 </Button>
-                <Button {...sign} onPress={onSign} fullWidth>
+                <SwipeButton {...sign} onSwipe={onSign} fullWidth>
                     {translate("slideToAccept")}
-                </Button>
+                </SwipeButton>
             </Col>
         </Col>
     );

--- a/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
+++ b/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
@@ -2,7 +2,6 @@ import { Col } from "@peersyst/react-native-components";
 import Button from "module/common/component/input/Button/Button";
 import { useTranslate } from "module/common/hook/useTranslate";
 import { SignatureScaffoldProps } from "./SignatureScaffold.types";
-import SwipeButton from "module/common/component/feedback/SwipeButton/SwipeButton";
 
 const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: SignatureScaffoldProps): JSX.Element => {
     const translate = useTranslate();
@@ -14,9 +13,9 @@ const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: Signatu
                 <Button {...reject} variant="text" onPress={onReject} fullWidth>
                     {translate("reject")}
                 </Button>
-                <SwipeButton {...sign} onSwipe={onSign} fullWidth>
+                <Button {...sign} onPress={onSign} fullWidth>
                     {translate("slideToAccept")}
-                </SwipeButton>
+                </Button>
             </Col>
         </Col>
     );


### PR DESCRIPTION
# [TA-1238] Fix ActionSlider dots to primary

## Tasks

- [[TA-1238] Fix ActionSlider dots to primary](https://www.notion.so/Fix-ActionSlider-dots-to-primary-72b854a6ad994d8ba32b54e7d3feadae?pvs=4)


## Changes

- `ActionsSliderRoot` styled component
- updated `ActionsSlider` with new styled component

### Visual changes

![IMG_0530](https://github.com/Peersyst/near-mobile-wallet/assets/68080871/93cc46c2-c54e-4398-9a99-e782e458de4a)
![IMG_0529](https://github.com/Peersyst/near-mobile-wallet/assets/68080871/99aa2a0a-1541-4e4d-acd0-b81c77f31c73)

