### PR TITLE
[TA-1207] Add contract blockchain links

### DIFF
--- a/src/config/config.tsx
+++ b/src/config/config.tsx
@@ -23,9 +23,9 @@ const config = createConfig({
     components: {
         BlockchainAddress: {
             blockchainLinks: {
-                mainnetAddress: envConfig.mainnetExplorerLink + "/address/",
+                mainnetAddress: envConfig.mainnetExplorerLink + "/accounts/",
                 mainnetTx: envConfig.mainnetExplorerLink + "/transactions/",
-                testnetAddress: envConfig.testnetExplorerLink + "/address/",
+                testnetAddress: envConfig.testnetExplorerLink + "/accounts/",
                 testnetTx: envConfig.testnetExplorerLink + "/transactions/",
             },
         },

--- a/src/module/signer/components/display/FunctionCallPermissions/FunctionCallPermissions.tsx
+++ b/src/module/signer/components/display/FunctionCallPermissions/FunctionCallPermissions.tsx
@@ -10,6 +10,7 @@ import { useTranslate } from "module/common/hook/useTranslate";
 import { convertYoctoToNear } from "near-peersyst-sdk";
 import { useFormatBalance } from "module/wallet/component/display/Balance/hook/useFormatBalance";
 import { BalanceProps } from "module/wallet/component/display/Balance/Balance.types";
+import BlockchainAddress from "module/common/component/display/BlockchainAddress/BlockchainAddress";
 
 const FunctionCallPermissions = ({
     permission: { allowance: allowanceInYocto = "", receiverId },
@@ -29,7 +30,11 @@ const FunctionCallPermissions = ({
             ))}
             <Container>
                 <Col gap={16} alignItems="center" justifyContent="center">
-                    <ActionDetailField label={translate("contract")} content={receiverId} LeftIcon={ClipboardListIcon} />
+                    <ActionDetailField
+                        label={translate("contract")}
+                        content={<BlockchainAddress variant="body2Strong" type="address" address={receiverId} action="link" />}
+                        LeftIcon={ClipboardListIcon}
+                    />
                     {!!allowanceInNEAR && (
                         <ActionDetailField
                             label={translate("networkFeeAllowance")}

--- a/src/module/signer/components/display/SignRequestDetails/actions/FunctionCallDetails.tsx
+++ b/src/module/signer/components/display/SignRequestDetails/actions/FunctionCallDetails.tsx
@@ -8,6 +8,7 @@ import { ClipboardListIcon, NearIcon } from "icons";
 import Balance from "module/wallet/component/display/Balance/Balance";
 import { convertYoctoToNear } from "near-peersyst-sdk";
 import { Col } from "@peersyst/react-native-components";
+import BlockchainAddress from "module/common/component/display/BlockchainAddress/BlockchainAddress";
 
 const FunctionCallDetails = ({ params, receiverId }: ActionDetailsProps): JSX.Element => {
     const { methodName, deposit, gas } = params as FunctionCallActionParams;
@@ -22,17 +23,23 @@ const FunctionCallDetails = ({ params, receiverId }: ActionDetailsProps): JSX.El
         >
             <Container>
                 <Col gap={16}>
-                    {receiverId && <ActionDetailField label={translate("contract")} content={receiverId} leftIcon={ClipboardListIcon} />}
-                    <ActionDetailField label={translate("methodName")} content={methodName} leftIcon={ClipboardListIcon} />
+                    {receiverId && (
+                        <ActionDetailField
+                            label={translate("contract")}
+                            content={<BlockchainAddress variant="body2Strong" action="link" address={receiverId} type="address" />}
+                            LeftIcon={ClipboardListIcon}
+                        />
+                    )}
+                    <ActionDetailField label={translate("methodName")} content={methodName} LeftIcon={ClipboardListIcon} />
                     <ActionDetailField
                         label={translate("gas")}
                         content={<Balance variant="body2Strong" balance={convertYoctoToNear(gas)} units="token" />}
-                        leftIcon={NearIcon}
+                        LeftIcon={NearIcon}
                     />
                     <ActionDetailField
                         label={translate("deposit")}
                         content={<Balance variant="body2Strong" balance={convertYoctoToNear(deposit)} units="token" />}
-                        leftIcon={NearIcon}
+                        LeftIcon={NearIcon}
                     />
                 </Col>
             </Container>

--- a/src/module/signer/components/display/SignRequestDetails/actions/StakeDetails.tsx
+++ b/src/module/signer/components/display/SignRequestDetails/actions/StakeDetails.tsx
@@ -4,6 +4,8 @@ import { StakeActionParams } from "../actions.types";
 import { useTranslate } from "module/common/hook/useTranslate";
 import Container from "module/common/component/display/Container/Container";
 import Balance from "module/wallet/component/display/Balance/Balance";
+import ActionDetailField from "../../ActionDetailField/ActionDetailField";
+import { NearIcon } from "icons";
 
 const StakeDetails = ({ params }: ActionDetailsProps): JSX.Element => {
     const { stake } = params as StakeActionParams;
@@ -12,7 +14,11 @@ const StakeDetails = ({ params }: ActionDetailsProps): JSX.Element => {
     return (
         <ActionDetailsScaffold header={translate("stakeAction")} description={translate("stakeActionDescription")}>
             <Container>
-                <Balance variant="body2Strong" balance={stake} units="token" />
+                <ActionDetailField
+                    label={translate("deposit")}
+                    content={<Balance variant="body2Strong" balance={stake} units="token" />}
+                    LeftIcon={NearIcon}
+                />
             </Container>
         </ActionDetailsScaffold>
     );

--- a/src/module/signer/components/display/SignRequestDetails/actions/TransferDetails.tsx
+++ b/src/module/signer/components/display/SignRequestDetails/actions/TransferDetails.tsx
@@ -22,12 +22,12 @@ const TransferDetails = ({ params, receiverId }: ActionDetailsProps): JSX.Elemen
                     <ActionDetailField
                         label={translate("receiver")}
                         content={<BlockchainAddress variant="body2Strong" address={receiverId!} type="address" />}
-                        leftIcon={UserIcon}
+                        LeftIcon={UserIcon}
                     />
                     <ActionDetailField
                         label={translate("deposit")}
                         content={<Balance variant="body2Strong" units="token" balance={convertYoctoToNear(deposit)} textAlign="center" />}
-                        leftIcon={NearIcon}
+                        LeftIcon={NearIcon}
                     />
                 </Col>
             </Container>


### PR DESCRIPTION
# [TA-1207] Add contract blockchain links

## Tasks

- [[TA-1207] Add contract blockchain links](https://www.notion.so/Add-contract-blockchain-links-a868319332904f8fb1d551abd893ac77?pvs=4)


## Changes

- Added `BlockchainAddress` component in smart contract id fields
- fixed explorer link due to changes (`address` -> `accounts`)
- `StakeDetails` missing refactor with `ActionDetailField`
