### PR TITLE
[TA-1234] Remove not supported sites from config

### DIFF
--- a/src/config/configs/config.base.json
+++ b/src/config/configs/config.base.json
@@ -48,14 +48,6 @@
                 "contractId": "asset-manager.orderly-network.near"
             },
             {
-                "name": "Rainbow Bridge",
-                "description": "The Rainbow Bridge allows developers to utilize Ethereum assets and smart contracts on NEAR—a fast, scalable, and low-cost environment.",
-                "url": "https://rainbowbridge.app/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/908e2c26-5fc0-48da-9281-e4b931d8c73d.png",
-                "tag": "bridge",
-                "contractId": ""
-            },
-            {
                 "name": "Learn NEAR Club",
                 "description": "Learn how to use and build on NEAR and Earn NEAR.",
                 "url": "https://learnnear.club/",
@@ -110,14 +102,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/915c1657-8485-4c92-80a0-c455b6f45057.png",
                 "tag": "dex",
                 "contractId": "v1.jumbo_exchange.near"
-            },
-            {
-                "name": "Jump Defi",
-                "description": "The only one-stop decentralized finance platform on NEAR Protocol.",
-                "url": "https://www.jumpdefi.xyz/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/b6391251-9b81-446d-bf54-7b5da892cd51.webp",
-                "tag": "dex",
-                "contractId": ""
             }
         ]
     }

--- a/src/config/configs/config.dev.json
+++ b/src/config/configs/config.dev.json
@@ -11,7 +11,7 @@
     },
     "signerFeature": {
         "enabled": true,
-        "backendUrl": "http://192.168.1.55:3001",
+        "backendUrl": "http://localhost:3001",
         "recommendedDApps": [
             {
                 "name": "Ref Finance",
@@ -20,14 +20,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/525f6f41-b6a1-46bd-94ef-23f64f09b4a2.png",
                 "tag": "dex",
                 "contractId": "asset-manager.orderly-network.near"
-            },
-            {
-                "name": "Rainbow Bridge",
-                "description": "The Rainbow Bridge allows developers to utilize Ethereum assets and smart contracts on NEAR—a fast, scalable, and low-cost environment.",
-                "url": "https://rainbowbridge.app/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/908e2c26-5fc0-48da-9281-e4b931d8c73d.png",
-                "tag": "bridge",
-                "contractId": ""
             },
             {
                 "name": "Learn NEAR Club",
@@ -84,14 +76,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/915c1657-8485-4c92-80a0-c455b6f45057.png",
                 "tag": "dex",
                 "contractId": "v1.jumbo_exchange.near"
-            },
-            {
-                "name": "Jump Defi",
-                "description": "The only one-stop decentralized finance platform on NEAR Protocol.",
-                "url": "https://www.jumpdefi.xyz/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/b6391251-9b81-446d-bf54-7b5da892cd51.webp",
-                "tag": "dex",
-                "contractId": ""
             }
         ],
         "dAppLogoFallback": ""


### PR DESCRIPTION
# [TA-1234] Remove not supported sites from config

## Tasks

- [[TA-1234] Remove not supported sites from config](https://www.notion.so/Remove-not-supported-sites-from-config-8bfb0b28c14f4860b22d8a3853ab1f73?pvs=4)

## Changes

- deleted `RainbowBridge` and `Jump Defi` dapps from config
