### PR TITLE
[TA-1230] Refactor ConnectedSite component

### DIFF
--- a/src/config/config.declarations.d.ts
+++ b/src/config/config.declarations.d.ts
@@ -1,6 +1,6 @@
 import "@peersyst/react-native-components";
 import { Validator } from "@peersyst/react-native-components";
-import { DApp } from "module/signer/components/display/DApp/DApp.types";
+import { DApp } from "module/signer/types";
 import { TransakOnRampQueryParams } from "module/transak";
 import { TFunction } from "react-i18next";
 

--- a/src/locale/locales/en/common.json
+++ b/src/locale/locales/en/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/es/common.json
+++ b/src/locale/locales/es/common.json
@@ -306,5 +306,6 @@
     "search": "Buscar",
     "all": "Todas",
     "dAppCategories": "Categorías de dApps",
-    "disconnectDApp": "Para confirmar la desconexión de la dApp, por favor, pulse el botón de desconectar."
+    "disconnectDApp": "Para confirmar la desconexión de la dApp, por favor, pulse el botón de desconectar.",
+    "connectedWith": "Conectado con {{name}}:"
 }

--- a/src/locale/locales/fr/common.json
+++ b/src/locale/locales/fr/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/id/common.json
+++ b/src/locale/locales/id/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/it/common.json
+++ b/src/locale/locales/it/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/pt/common.json
+++ b/src/locale/locales/pt/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/ru/common.json
+++ b/src/locale/locales/ru/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/uk/common.json
+++ b/src/locale/locales/uk/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/vi/common.json
+++ b/src/locale/locales/vi/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/zh-CN/common.json
+++ b/src/locale/locales/zh-CN/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/locale/locales/zh-TW/common.json
+++ b/src/locale/locales/zh-TW/common.json
@@ -306,5 +306,6 @@
     "search": "Search",
     "all": "All",
     "dAppCategories": "dApp categories",
-    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again."
+    "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
+    "connectedWith": "Connected with {{name}}:"
 }

--- a/src/module/common/component/feedback/Actionable/Actionable.styles.ts
+++ b/src/module/common/component/feedback/Actionable/Actionable.styles.ts
@@ -1,7 +1,11 @@
-import { Row } from "@peersyst/react-native-components";
+import { IconButton, Row } from "@peersyst/react-native-components";
 import styled from "@peersyst/react-native-styled";
 
 export const ActionableRoot = styled(Row)(() => ({
     alignItems: "center",
     justifyContent: "center",
+}));
+
+export const ActionableIcon = styled(IconButton)(({ theme }) => ({
+    color: theme.palette.gray[300],
 }));

--- a/src/module/common/component/feedback/Actionable/Actionable.styles.ts
+++ b/src/module/common/component/feedback/Actionable/Actionable.styles.ts
@@ -1,11 +1,6 @@
-import { IconButton, Row } from "@peersyst/react-native-components";
+import { ElementStyler } from "@peersyst/react-native-components";
 import styled from "@peersyst/react-native-styled";
 
-export const ActionableRoot = styled(Row)(() => ({
-    alignItems: "center",
-    justifyContent: "center",
-}));
-
-export const ActionableIcon = styled(IconButton)(({ theme }) => ({
+export const ActionRoot = styled(ElementStyler)(({ theme }) => ({
     color: theme.palette.gray[300],
 }));

--- a/src/module/common/component/feedback/Actionable/Actionable.tsx
+++ b/src/module/common/component/feedback/Actionable/Actionable.tsx
@@ -1,14 +1,13 @@
 import { Col } from "@peersyst/react-native-components";
-import { ActionableRoot } from "./Actionable.styles";
-import Button from "../../input/Button/Button";
+import { ActionableRoot, ActionableIcon } from "./Actionable.styles";
 import { ActionableProps } from "./Actionable.types";
 
-const Actionable = ({ actionText, onAction, position = "right", actionProps, children, ...rest }: ActionableProps): JSX.Element => {
+const Actionable = ({ Action, onAction, position = "right", actionProps, children, ...rest }: ActionableProps): JSX.Element => {
     const action: JSX.Element = (
         <Col justifyContent="center">
-            <Button onPress={onAction} {...actionProps}>
-                {actionText}
-            </Button>
+            <ActionableIcon onPress={onAction} {...actionProps}>
+                <Action />
+            </ActionableIcon>
         </Col>
     );
 

--- a/src/module/common/component/feedback/Actionable/Actionable.tsx
+++ b/src/module/common/component/feedback/Actionable/Actionable.tsx
@@ -1,17 +1,20 @@
-import { Col } from "@peersyst/react-native-components";
-import { ActionableRoot } from "./Actionable.styles";
+import { Row } from "@peersyst/react-native-components";
 import { ActionableProps } from "./Actionable.types";
+import { TouchableOpacity } from "react-native-gesture-handler";
+import { ActionRoot } from "./Actionable.styles";
 
-const Actionable = ({ action: actionProp, position = "right", children, ...rest }: ActionableProps): JSX.Element => {
-    const action: JSX.Element = <Col justifyContent="center">{actionProp}</Col>;
+const Actionable = ({ action: actionProp, onAction, position = "right", children, ...rest }: ActionableProps): JSX.Element => {
+    const action: JSX.Element = <ActionRoot>{actionProp}</ActionRoot>;
 
     const [firstItem, secondItem] = position === "left" ? [action, children] : [children, action];
 
     return (
-        <ActionableRoot {...rest}>
-            {firstItem}
-            {secondItem}
-        </ActionableRoot>
+        <TouchableOpacity activeOpacity={0.6} onPress={onAction}>
+            <Row justifyContent="center" alignItems="center" {...rest}>
+                {firstItem}
+                {secondItem}
+            </Row>
+        </TouchableOpacity>
     );
 };
 

--- a/src/module/common/component/feedback/Actionable/Actionable.tsx
+++ b/src/module/common/component/feedback/Actionable/Actionable.tsx
@@ -1,15 +1,9 @@
 import { Col } from "@peersyst/react-native-components";
-import { ActionableRoot, ActionableIcon } from "./Actionable.styles";
+import { ActionableRoot } from "./Actionable.styles";
 import { ActionableProps } from "./Actionable.types";
 
-const Actionable = ({ Action, onAction, position = "right", actionProps, children, ...rest }: ActionableProps): JSX.Element => {
-    const action: JSX.Element = (
-        <Col justifyContent="center">
-            <ActionableIcon onPress={onAction} {...actionProps}>
-                <Action />
-            </ActionableIcon>
-        </Col>
-    );
+const Actionable = ({ action: actionProp, position = "right", children, ...rest }: ActionableProps): JSX.Element => {
+    const action: JSX.Element = <Col justifyContent="center">{actionProp}</Col>;
 
     const [firstItem, secondItem] = position === "left" ? [action, children] : [children, action];
 

--- a/src/module/common/component/feedback/Actionable/Actionable.types.ts
+++ b/src/module/common/component/feedback/Actionable/Actionable.types.ts
@@ -1,11 +1,11 @@
-import { RowProps } from "@peersyst/react-native-components";
-import { ButtonProps } from "../../input/Button/Button.types";
+import { IconButtonProps, RowProps, SvgIconProps } from "@peersyst/react-native-components";
+import { JSXElementConstructor } from "react";
 
 type ActionablePosition = "left" | "right";
 
 export interface ActionableProps extends RowProps {
+    Action: JSXElementConstructor<SvgIconProps>;
     onAction: () => void;
-    actionText: string;
-    actionProps?: ButtonProps;
+    actionProps?: Omit<IconButtonProps, "onPress">;
     position?: ActionablePosition;
 }

--- a/src/module/common/component/feedback/Actionable/Actionable.types.ts
+++ b/src/module/common/component/feedback/Actionable/Actionable.types.ts
@@ -5,5 +5,6 @@ type ActionablePosition = "left" | "right";
 
 export interface ActionableProps extends RowProps {
     action: ReactElement;
+    onAction: () => void;
     position?: ActionablePosition;
 }

--- a/src/module/common/component/feedback/Actionable/Actionable.types.ts
+++ b/src/module/common/component/feedback/Actionable/Actionable.types.ts
@@ -1,11 +1,9 @@
-import { IconButtonProps, RowProps, SvgIconProps } from "@peersyst/react-native-components";
-import { JSXElementConstructor } from "react";
+import { RowProps } from "@peersyst/react-native-components";
+import { ReactElement } from "react";
 
 type ActionablePosition = "left" | "right";
 
 export interface ActionableProps extends RowProps {
-    Action: JSXElementConstructor<SvgIconProps>;
-    onAction: () => void;
-    actionProps?: Omit<IconButtonProps, "onPress">;
+    action: ReactElement;
     position?: ActionablePosition;
 }

--- a/src/module/signer/components/layout/ActionDetailsScaffold/ActionDetailsScaffold.types.ts
+++ b/src/module/signer/components/layout/ActionDetailsScaffold/ActionDetailsScaffold.types.ts
@@ -3,7 +3,7 @@ import { PropsWithChildren } from "react";
 import { ActionPreviewProps } from "../../display/ActionPreview/ActionPreview.types";
 
 export interface ActionDetailsScaffoldProps extends PropsWithChildren {
-    header: ReactChild;
+    header?: ReactChild;
     description?: ReactChild;
     showPreview?: boolean;
     previewProps?: ActionPreviewProps;

--- a/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
+++ b/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
@@ -2,6 +2,7 @@ import { Col } from "@peersyst/react-native-components";
 import Button from "module/common/component/input/Button/Button";
 import { useTranslate } from "module/common/hook/useTranslate";
 import { SignatureScaffoldProps } from "./SignatureScaffold.types";
+import SwipeButton from "module/common/component/feedback/SwipeButton/SwipeButton";
 
 const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: SignatureScaffoldProps): JSX.Element => {
     const translate = useTranslate();
@@ -13,9 +14,9 @@ const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: Signatu
                 <Button {...reject} variant="text" onPress={onReject} fullWidth>
                     {translate("reject")}
                 </Button>
-                <Button {...sign} onPress={onSign} fullWidth>
+                <SwipeButton {...sign} onSwipe={onSign} fullWidth>
                     {translate("slideToAccept")}
-                </Button>
+                </SwipeButton>
             </Col>
         </Col>
     );

--- a/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
+++ b/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
@@ -2,7 +2,6 @@ import { Col } from "@peersyst/react-native-components";
 import Button from "module/common/component/input/Button/Button";
 import { useTranslate } from "module/common/hook/useTranslate";
 import { SignatureScaffoldProps } from "./SignatureScaffold.types";
-import SwipeButton from "module/common/component/feedback/SwipeButton/SwipeButton";
 
 const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: SignatureScaffoldProps): JSX.Element => {
     const translate = useTranslate();
@@ -14,9 +13,9 @@ const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: Signatu
                 <Button {...reject} variant="text" onPress={onReject} fullWidth>
                     {translate("reject")}
                 </Button>
-                <SwipeButton {...sign} onSwipe={onSign} fullWidth>
+                <Button {...sign} onPress={onSign} fullWidth>
                     {translate("slideToAccept")}
-                </SwipeButton>
+                </Button>
             </Col>
         </Col>
     );

--- a/src/module/signer/queries/useConnectedSiteLogo.ts
+++ b/src/module/signer/queries/useConnectedSiteLogo.ts
@@ -1,5 +1,5 @@
 import { config } from "config";
-import Queries from "query/queries";
+import Queries from "../../../query/queries";
 import { UseQueryResult, useQuery } from "react-query";
 
 export default function useConnectedSiteLogo(contractId: string): UseQueryResult<string, unknown> {

--- a/src/module/signer/queries/useConnectedSiteLogo.ts
+++ b/src/module/signer/queries/useConnectedSiteLogo.ts
@@ -1,0 +1,14 @@
+import { config } from "config";
+import Queries from "query/queries";
+import { UseQueryResult, useQuery } from "react-query";
+
+export default function useConnectedSiteLogo(contractId: string): UseQueryResult<string, unknown> {
+    return useQuery(
+        [Queries.GET_CONNECTED_SITE_LOGO, contractId],
+        () =>
+            new Promise<string>((resolve) => {
+                const logo = config.signerFeature.recommendedDApps.find(({ contractId: id }) => id === contractId)?.logoUrl || "";
+                resolve(logo);
+            }),
+    );
+}

--- a/src/module/wallet/component/display/ConnectedSite/ConnectedSite.styles.ts
+++ b/src/module/wallet/component/display/ConnectedSite/ConnectedSite.styles.ts
@@ -3,7 +3,7 @@ import styled from "@peersyst/react-native-styled";
 import { config } from "config";
 
 export const ConnectedSiteRoot = styled(Row)(() => ({
-    height: 76,
+    height: 100,
     alignItems: "center",
 }));
 

--- a/src/module/wallet/component/display/ConnectedSite/ConnectedSite.styles.ts
+++ b/src/module/wallet/component/display/ConnectedSite/ConnectedSite.styles.ts
@@ -1,7 +1,15 @@
-import { Row } from "@peersyst/react-native-components";
+import { Row, Image } from "@peersyst/react-native-components";
 import styled from "@peersyst/react-native-styled";
+import { config } from "config";
 
 export const ConnectedSiteRoot = styled(Row)(() => ({
     height: 76,
     alignItems: "center",
+}));
+
+export const ConnectedSiteLogo = styled(Image, { fallback: { uri: config.signerFeature.dAppLogoFallback } })(({ theme }) => ({
+    backgroundColor: theme.palette.overlay["8%"],
+    borderRadius: theme.borderRadiusSm,
+    width: 60,
+    aspectRatio: 1,
 }));

--- a/src/module/wallet/component/display/ConnectedSite/ConnectedSite.tsx
+++ b/src/module/wallet/component/display/ConnectedSite/ConnectedSite.tsx
@@ -1,19 +1,17 @@
 import { Col, Hash } from "@peersyst/react-native-components";
 import { ConnectedSiteProps } from "./ConnectedSite.types";
-import CardIcon from "module/common/component/display/CardIcon/CardIcon";
-import { LaptopIcon } from "icons";
 import Typography from "module/common/component/display/Typography/Typography";
-import { ConnectedSiteRoot } from "./ConnectedSite.styles";
+import { ConnectedSiteRoot, ConnectedSiteLogo } from "./ConnectedSite.styles";
 import { TouchableWithoutFeedback } from "react-native";
 
 const ConnectedSite = ({ site: { name, publicKey } }: ConnectedSiteProps) => {
     return (
         <TouchableWithoutFeedback>
             <ConnectedSiteRoot flex={1} gap={12}>
-                <CardIcon Icon={LaptopIcon} active={true} />
+                <ConnectedSiteLogo source={{ uri: "" }} />
                 <Col flex={1}>
                     <Typography variant="body3Strong">{name}</Typography>
-                    <Hash variant="body4Regular" hash={publicKey.slice(8)} ellipsis="middle" length={9} />
+                    <Hash variant="body4Regular" hash={publicKey.slice(8)} ellipsis="middle" />
                 </Col>
             </ConnectedSiteRoot>
         </TouchableWithoutFeedback>

--- a/src/module/wallet/component/display/ConnectedSite/ConnectedSite.tsx
+++ b/src/module/wallet/component/display/ConnectedSite/ConnectedSite.tsx
@@ -3,15 +3,23 @@ import { ConnectedSiteProps } from "./ConnectedSite.types";
 import Typography from "module/common/component/display/Typography/Typography";
 import { ConnectedSiteRoot, ConnectedSiteLogo } from "./ConnectedSite.styles";
 import { TouchableWithoutFeedback } from "react-native";
+import useConnectedSiteLogo from "module/signer/queries/useConnectedSiteLogo";
 
-const ConnectedSite = ({ site: { name, publicKey } }: ConnectedSiteProps) => {
+const ConnectedSite = ({
+    site: {
+        name,
+        accessKey: { public_key },
+    },
+}: ConnectedSiteProps) => {
+    const { data: siteLogo, isLoading } = useConnectedSiteLogo(name);
+
     return (
         <TouchableWithoutFeedback>
             <ConnectedSiteRoot flex={1} gap={12}>
-                <ConnectedSiteLogo source={{ uri: "" }} />
+                <ConnectedSiteLogo loading={isLoading} source={{ uri: siteLogo }} />
                 <Col flex={1}>
                     <Typography variant="body3Strong">{name}</Typography>
-                    <Hash variant="body4Regular" hash={publicKey.slice(8)} ellipsis="middle" />
+                    <Hash variant="body4Regular" hash={public_key.slice(8)} ellipsis="middle" />
                 </Col>
             </ConnectedSiteRoot>
         </TouchableWithoutFeedback>

--- a/src/module/wallet/component/display/ConnectedSite/ConnectedSite.tsx
+++ b/src/module/wallet/component/display/ConnectedSite/ConnectedSite.tsx
@@ -2,7 +2,6 @@ import { Col, Hash } from "@peersyst/react-native-components";
 import { ConnectedSiteProps } from "./ConnectedSite.types";
 import Typography from "module/common/component/display/Typography/Typography";
 import { ConnectedSiteRoot, ConnectedSiteLogo } from "./ConnectedSite.styles";
-import { TouchableWithoutFeedback } from "react-native";
 import useConnectedSiteLogo from "module/signer/queries/useConnectedSiteLogo";
 
 const ConnectedSite = ({
@@ -14,15 +13,13 @@ const ConnectedSite = ({
     const { data: siteLogo, isLoading } = useConnectedSiteLogo(name);
 
     return (
-        <TouchableWithoutFeedback>
-            <ConnectedSiteRoot flex={1} gap={12}>
-                <ConnectedSiteLogo loading={isLoading} source={{ uri: siteLogo }} />
-                <Col flex={1}>
-                    <Typography variant="body3Strong">{name}</Typography>
-                    <Hash variant="body4Regular" hash={public_key.slice(8)} ellipsis="middle" />
-                </Col>
-            </ConnectedSiteRoot>
-        </TouchableWithoutFeedback>
+        <ConnectedSiteRoot flex={1} gap={12}>
+            <ConnectedSiteLogo loading={isLoading} source={{ uri: siteLogo }} />
+            <Col flex={1}>
+                <Typography variant="body3Strong">{name}</Typography>
+                <Hash variant="body4Regular" hash={public_key.slice(8)} ellipsis="middle" />
+            </Col>
+        </ConnectedSiteRoot>
     );
 };
 

--- a/src/module/wallet/component/display/ConnectedSite/ConnectedSite.types.ts
+++ b/src/module/wallet/component/display/ConnectedSite/ConnectedSite.types.ts
@@ -1,6 +1,8 @@
+import { AccessKeyInfoView } from "near-api-js/lib/providers/provider";
+
 export interface ConnectedSite {
-    publicKey: string;
     name: string;
+    accessKey: AccessKeyInfoView;
 }
 
 export interface ConnectedSiteProps {

--- a/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.tsx
+++ b/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.tsx
@@ -4,7 +4,6 @@ import { ConnectedSiteProps } from "../../display/ConnectedSite/ConnectedSite.ty
 import { useState } from "react";
 import { ChevronRightIcon } from "icons";
 import DisconnectSiteModal from "../DisconnectSiteModal/DisconnectSiteModal";
-import { ActionableIcon } from "module/common/component/feedback/Actionable/Actionable.styles";
 
 export type ActionableConnectedSiteProps = Pick<ConnectedSiteProps, "site">;
 
@@ -15,14 +14,7 @@ const ActionableConnectedSite = ({ site }: ActionableConnectedSiteProps) => {
     const closeDisconnectModal = () => setOpenDisconnectModal(false);
 
     return (
-        <Actionable
-            action={
-                <ActionableIcon onPress={handleAction}>
-                    <ChevronRightIcon />
-                </ActionableIcon>
-            }
-            gap={12}
-        >
+        <Actionable action={<ChevronRightIcon />} onAction={handleAction} gap={12}>
             <ConnectedSite site={site} />
             <DisconnectSiteModal site={site} open={openDisconnectModal} onClose={closeDisconnectModal} />
         </Actionable>

--- a/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.tsx
+++ b/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.tsx
@@ -1,56 +1,22 @@
 import ConnectedSite from "../../display/ConnectedSite/ConnectedSite";
 import Actionable from "module/common/component/feedback/Actionable/Actionable";
 import { ConnectedSiteProps } from "../../display/ConnectedSite/ConnectedSite.types";
-import { useTranslate } from "module/common/hook/useTranslate";
 import { useState } from "react";
-import { Dialog, useToast } from "@peersyst/react-native-components";
-import Typography from "module/common/component/display/Typography/Typography";
-import useDeleteKey from "module/wallet/query/useDeleteKey";
 import { ChevronRightIcon } from "icons";
+import DisconnectSiteModal from "../DisconnectSiteModal/DisconnectSiteModal";
 
 export type ActionableConnectedSiteProps = Pick<ConnectedSiteProps, "site">;
 
 const ActionableConnectedSite = ({ site }: ActionableConnectedSiteProps) => {
-    const translate = useTranslate();
-    const [openDialog, setOpenDialog] = useState(false);
+    const [openDisconnectModal, setOpenDisconnectModal] = useState(false);
 
-    const { showToast } = useToast();
-
-    const handleAction = () => setOpenDialog(true);
-    const closeDialog = () => setOpenDialog(false);
-
-    const handleSuccess = () => {
-        showToast(translate("disconnectSuccessfully"), { type: "success" });
-        closeDialog();
-    };
-
-    const { mutate: deleteSite, isLoading } = useDeleteKey({ onSuccess: handleSuccess });
+    const handleAction = () => setOpenDisconnectModal(true);
+    const closeDisconnectModal = () => setOpenDisconnectModal(false);
 
     return (
         <Actionable Action={ChevronRightIcon} onAction={handleAction} gap={12}>
             <ConnectedSite site={site} />
-            <Dialog
-                open={openDialog}
-                content={
-                    <Typography variant="body2Strong" textAlign="center" style={{ marginBottom: 24 }}>
-                        {translate("deleteKeyConfirmation", { name: site.name })}
-                    </Typography>
-                }
-                onExited={closeDialog}
-                buttons={[
-                    {
-                        type: "destructive",
-                        text: translate("disconnect"),
-                        action: () => deleteSite(site.publicKey),
-                        loading: isLoading,
-                    },
-                    {
-                        variant: "text",
-                        action: closeDialog,
-                        text: translate("cancel"),
-                    },
-                ]}
-            />
+            <DisconnectSiteModal site={site} open={openDisconnectModal} onClose={closeDisconnectModal} />
         </Actionable>
     );
 };

--- a/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.tsx
+++ b/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { Dialog, useToast } from "@peersyst/react-native-components";
 import Typography from "module/common/component/display/Typography/Typography";
 import useDeleteKey from "module/wallet/query/useDeleteKey";
+import { ChevronRightIcon } from "icons";
 
 export type ActionableConnectedSiteProps = Pick<ConnectedSiteProps, "site">;
 
@@ -26,7 +27,7 @@ const ActionableConnectedSite = ({ site }: ActionableConnectedSiteProps) => {
     const { mutate: deleteSite, isLoading } = useDeleteKey({ onSuccess: handleSuccess });
 
     return (
-        <Actionable onAction={handleAction} actionText={translate("disconnect")} actionProps={{ size: "sm", variant: "outlined" }} gap={12}>
+        <Actionable Action={ChevronRightIcon} onAction={handleAction} gap={12}>
             <ConnectedSite site={site} />
             <Dialog
                 open={openDialog}
@@ -45,6 +46,7 @@ const ActionableConnectedSite = ({ site }: ActionableConnectedSiteProps) => {
                     },
                     {
                         variant: "text",
+                        action: closeDialog,
                         text: translate("cancel"),
                     },
                 ]}

--- a/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.tsx
+++ b/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.tsx
@@ -4,6 +4,7 @@ import { ConnectedSiteProps } from "../../display/ConnectedSite/ConnectedSite.ty
 import { useState } from "react";
 import { ChevronRightIcon } from "icons";
 import DisconnectSiteModal from "../DisconnectSiteModal/DisconnectSiteModal";
+import { ActionableIcon } from "module/common/component/feedback/Actionable/Actionable.styles";
 
 export type ActionableConnectedSiteProps = Pick<ConnectedSiteProps, "site">;
 
@@ -14,7 +15,14 @@ const ActionableConnectedSite = ({ site }: ActionableConnectedSiteProps) => {
     const closeDisconnectModal = () => setOpenDisconnectModal(false);
 
     return (
-        <Actionable Action={ChevronRightIcon} onAction={handleAction} gap={12}>
+        <Actionable
+            action={
+                <ActionableIcon onPress={handleAction}>
+                    <ChevronRightIcon />
+                </ActionableIcon>
+            }
+            gap={12}
+        >
             <ConnectedSite site={site} />
             <DisconnectSiteModal site={site} open={openDisconnectModal} onClose={closeDisconnectModal} />
         </Actionable>

--- a/src/module/wallet/component/feedback/ConnectedSitesModal/ConnectedSitesModal.tsx
+++ b/src/module/wallet/component/feedback/ConnectedSitesModal/ConnectedSitesModal.tsx
@@ -1,22 +1,29 @@
-import { Col, createModal } from "@peersyst/react-native-components";
-import CardSelectModal from "module/common/component/feedback/CardSelectModal/CardSelectModal";
+import { Col, ExposedBackdropProps, createModal } from "@peersyst/react-native-components";
 import { useTranslate } from "module/common/hook/useTranslate";
 import ActionableConnectedSitesList from "../ConnectedSitesList/ConnectedSitesList";
 import useGetConnectedSites from "module/wallet/query/useGetConnectedSites";
+import CardNavigatorModal from "module/common/component/navigation/CardNavigatorModal/CardNavigatorModal";
+import { useControlled } from "@peersyst/react-hooks";
 
-const ConnectedSitesModal = createModal((props): JSX.Element => {
+const ConnectedSitesModal = createModal(({ defaultOpen, open: openProp, onClose, ...props }: ExposedBackdropProps): JSX.Element => {
     const translate = useTranslate();
+    const [open, setOpen] = useControlled(defaultOpen, openProp, onClose);
 
     const { sites, isLoading, refetch } = useGetConnectedSites();
 
     return (
-        <CardSelectModal title={translate("connectedSites")} dismissal="hide" {...props} style={{ height: "60%" }}>
+        <CardNavigatorModal
+            open={open}
+            navbar={{ title: translate("connectedSites").toUpperCase(), back: true, onBack: () => setOpen(false) }}
+            style={{ height: "60%" }}
+            {...props}
+        >
             <Col flex={1}>
                 <Col style={{ position: "absolute", height: "100%", width: "100%" }}>
                     <ActionableConnectedSitesList sites={sites} loading={isLoading} onRefresh={refetch} />
                 </Col>
             </Col>
-        </CardSelectModal>
+        </CardNavigatorModal>
     );
 });
 

--- a/src/module/wallet/component/feedback/ConnectedSitesModal/ConnectedSitesModal.types.ts
+++ b/src/module/wallet/component/feedback/ConnectedSitesModal/ConnectedSitesModal.types.ts
@@ -1,0 +1,1 @@
+export interface ConnectedSitesModalProps {}

--- a/src/module/wallet/component/feedback/ConnectedSitesModal/ConnectedSitesModal.types.ts
+++ b/src/module/wallet/component/feedback/ConnectedSitesModal/ConnectedSitesModal.types.ts
@@ -1,1 +1,0 @@
-export interface ConnectedSitesModalProps {}

--- a/src/module/wallet/component/feedback/DisconnectSiteModal/DisconnectSiteModal.tsx
+++ b/src/module/wallet/component/feedback/DisconnectSiteModal/DisconnectSiteModal.tsx
@@ -1,0 +1,26 @@
+import { createModal } from "@peersyst/react-native-components";
+import { DisconnectSiteModalProps } from "./DisconnectSiteModal.types";
+import CardNavigatorModal from "module/common/component/navigation/CardNavigatorModal/CardNavigatorModal";
+import { useControlled } from "@peersyst/react-hooks";
+import { useTranslate } from "module/common/hook/useTranslate";
+import Typography from "module/common/component/display/Typography/Typography";
+
+const DisconnectSiteModal = createModal(
+    ({ site, defaultOpen, open: openProp, onClose, ...modalProps }: DisconnectSiteModalProps): JSX.Element => {
+        const translate = useTranslate();
+        const [open, setOpen] = useControlled(defaultOpen, openProp, onClose);
+
+        return (
+            <CardNavigatorModal
+                open={open}
+                navbar={{ back: true, onBack: () => setOpen(false), title: translate("connectedWith", { name: site.name }).toUpperCase() }}
+                style={{ height: "90%" }}
+                {...modalProps}
+            >
+                <Typography variant="body2Strong">{site.name}</Typography>
+            </CardNavigatorModal>
+        );
+    },
+);
+
+export default DisconnectSiteModal;

--- a/src/module/wallet/component/feedback/DisconnectSiteModal/DisconnectSiteModal.types.ts
+++ b/src/module/wallet/component/feedback/DisconnectSiteModal/DisconnectSiteModal.types.ts
@@ -1,0 +1,6 @@
+import { ExposedBackdropProps } from "@peersyst/react-native-components";
+import { ConnectedSite } from "../../display/ConnectedSite/ConnectedSite.types";
+
+export interface DisconnectSiteModalProps extends ExposedBackdropProps {
+    site: ConnectedSite;
+}

--- a/src/module/wallet/hook/useParseConnectedSites.ts
+++ b/src/module/wallet/hook/useParseConnectedSites.ts
@@ -22,7 +22,7 @@ export default function useParsedConnectedSites() {
                 .map((accessKey: AccessKeyInfoView) => {
                     if (accessKey.public_key === publicKey.toString()) return undefined;
                     return {
-                        publicKey: accessKey.public_key,
+                        accessKey: accessKey,
                         name: parseAccessKeyName(accessKey),
                     };
                 })

--- a/src/query/queries.ts
+++ b/src/query/queries.ts
@@ -16,6 +16,7 @@ enum Queries {
     GET_ACCOUNT_ACCESS_KEYS = "get-account-access-keys",
     IS_DAPP_CONNECTED = "is-dapp-connected",
     RECOMMENDED_DAPPS = "recommended-dapps",
+    GET_CONNECTED_SITE_LOGO = "get-connected-site-logo",
 }
 
 export default Queries;

--- a/test/unit/src/module/common/component/feedback/Actionable/Actionable.spec.tsx
+++ b/test/unit/src/module/common/component/feedback/Actionable/Actionable.spec.tsx
@@ -1,17 +1,33 @@
 import Typography from "module/common/component/display/Typography/Typography";
 import Actionable from "module/common/component/feedback/Actionable/Actionable";
-import { render, screen } from "test-utils";
+import { fireEvent, render, screen } from "test-utils";
 
 describe("Actionable", () => {
     test("Renders correctly", () => {
         const mockAction = <Typography variant="body2Strong">Action</Typography>;
         render(
-            <Actionable action={mockAction}>
+            <Actionable action={mockAction} onAction={jest.fn}>
                 <Typography variant="body2Strong">Test</Typography>
             </Actionable>,
         );
 
         expect(screen.getByText("Action")).toBeDefined();
         expect(screen.getByText("Test")).toBeDefined();
+    });
+
+    test("Renders correctly", () => {
+        const mockAction = <Typography variant="body2Strong">Action</Typography>;
+        const mockOnAction = jest.fn();
+        render(
+            <Actionable action={mockAction} onAction={mockOnAction}>
+                <Typography variant="body2Strong">Test</Typography>
+            </Actionable>,
+        );
+
+        const pressableAction = screen.getByText("Action");
+
+        fireEvent.press(pressableAction);
+
+        expect(mockOnAction).toHaveBeenCalled();
     });
 });

--- a/test/unit/src/module/common/component/feedback/Actionable/Actionable.spec.tsx
+++ b/test/unit/src/module/common/component/feedback/Actionable/Actionable.spec.tsx
@@ -1,3 +1,4 @@
+import { ChevronDownIcon } from "icons";
 import Typography from "module/common/component/display/Typography/Typography";
 import Actionable from "module/common/component/feedback/Actionable/Actionable";
 import { fireEvent, render, screen } from "test-utils";
@@ -5,25 +6,25 @@ import { fireEvent, render, screen } from "test-utils";
 describe("Actionable", () => {
     test("Renders correctly", () => {
         render(
-            <Actionable actionText="action" onAction={jest.fn}>
+            <Actionable Action={ChevronDownIcon} onAction={jest.fn}>
                 <Typography variant="body2Strong">Test</Typography>
             </Actionable>,
         );
 
+        expect(screen.getByTestId("ChevronDownIcon")).toBeDefined();
         expect(screen.getByText("Test")).toBeDefined();
-        expect(screen.getByText("action")).toBeDefined();
     });
 
     test("Calls onAction when actionable is pressed", () => {
         const mockOnAction = jest.fn();
 
         render(
-            <Actionable actionText="action" onAction={mockOnAction}>
+            <Actionable Action={ChevronDownIcon} onAction={mockOnAction}>
                 <Typography variant="body2Strong">Test</Typography>
             </Actionable>,
         );
 
-        const actionButton = screen.getByRole("button", { name: "action" });
+        const actionButton = screen.getByRole("button");
         fireEvent.press(actionButton);
 
         expect(mockOnAction).toHaveBeenCalledTimes(1);

--- a/test/unit/src/module/common/component/feedback/Actionable/Actionable.spec.tsx
+++ b/test/unit/src/module/common/component/feedback/Actionable/Actionable.spec.tsx
@@ -1,32 +1,17 @@
-import { ChevronDownIcon } from "icons";
 import Typography from "module/common/component/display/Typography/Typography";
 import Actionable from "module/common/component/feedback/Actionable/Actionable";
-import { fireEvent, render, screen } from "test-utils";
+import { render, screen } from "test-utils";
 
 describe("Actionable", () => {
     test("Renders correctly", () => {
+        const mockAction = <Typography variant="body2Strong">Action</Typography>;
         render(
-            <Actionable Action={ChevronDownIcon} onAction={jest.fn}>
+            <Actionable action={mockAction}>
                 <Typography variant="body2Strong">Test</Typography>
             </Actionable>,
         );
 
-        expect(screen.getByTestId("ChevronDownIcon")).toBeDefined();
+        expect(screen.getByText("Action")).toBeDefined();
         expect(screen.getByText("Test")).toBeDefined();
-    });
-
-    test("Calls onAction when actionable is pressed", () => {
-        const mockOnAction = jest.fn();
-
-        render(
-            <Actionable Action={ChevronDownIcon} onAction={mockOnAction}>
-                <Typography variant="body2Strong">Test</Typography>
-            </Actionable>,
-        );
-
-        const actionButton = screen.getByRole("button");
-        fireEvent.press(actionButton);
-
-        expect(mockOnAction).toHaveBeenCalledTimes(1);
     });
 });

--- a/test/unit/src/module/wallet/component/display/ConnectedSite/ConnectedSite.spec.tsx
+++ b/test/unit/src/module/wallet/component/display/ConnectedSite/ConnectedSite.spec.tsx
@@ -1,9 +1,11 @@
 import ConnectedSite from "module/wallet/component/display/ConnectedSite/ConnectedSite";
+import { ConnectedSite as ConnectedSiteType } from "module/wallet/component/display/ConnectedSite/ConnectedSite.types";
 import { render, screen } from "test-utils";
 
 describe("ConnectedSite", () => {
     test("Renders correctly", () => {
-        render(<ConnectedSite site={{ name: "test", publicKey: "test" }} />);
+        const mockConnectedSite = { name: "test", accessKey: { public_key: "publicKey" } } as ConnectedSiteType;
+        render(<ConnectedSite site={mockConnectedSite} />);
 
         expect(screen.getByText("test")).toBeDefined();
     });

--- a/test/unit/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.spec.tsx
+++ b/test/unit/src/module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite.spec.tsx
@@ -1,24 +1,13 @@
+import { ConnectedSite } from "module/wallet/component/display/ConnectedSite/ConnectedSite.types";
 import ActionableConnectedSite from "module/wallet/component/feedback/ActionableConnectedSite/ActionableConnectedSite";
-import { fireEvent, render, screen, translate } from "test-utils";
+import { render, screen } from "test-utils";
 
 describe("ActionableConnectedSite", () => {
     test("Renders correctly", () => {
-        const mockSite = { name: "test", publicKey: "test" };
+        const mockSite = { name: "test", accessKey: { public_key: "publicKey" } } as ConnectedSite;
 
         render(<ActionableConnectedSite site={mockSite} />);
 
         expect(screen.getByText(mockSite.name)).toBeDefined();
-    });
-
-    test("Renders dialog when action is clicked", () => {
-        const mockSite = { name: "test", publicKey: "test" };
-
-        render(<ActionableConnectedSite site={mockSite} />);
-
-        expect(screen.queryByText(translate("deleteKeyConfirmation", { name: mockSite.name }))).toBeNull();
-
-        fireEvent.press(screen.getByText(translate("disconnect")));
-
-        expect(screen.getByText(translate("deleteKeyConfirmation", { name: mockSite.name }))).toBeDefined();
     });
 });

--- a/test/unit/src/module/wallet/component/feedback/ConnectedSitesList/ConnectedSitesList.spec.tsx
+++ b/test/unit/src/module/wallet/component/feedback/ConnectedSitesList/ConnectedSitesList.spec.tsx
@@ -1,13 +1,11 @@
+import { ConnectedSite } from "module/wallet/component/display/ConnectedSite/ConnectedSite.types";
 import ConnectedSitesList from "module/wallet/component/feedback/ConnectedSitesList/ConnectedSitesList";
 import { render, screen, translate } from "test-utils";
 
 describe("ConnectedSitesList", () => {
     test("Renders correctly", () => {
-        const mockSites = [
-            { name: "test", publicKey: "test" },
-            { name: "test", publicKey: "test" },
-            { name: "test", publicKey: "test" },
-        ];
+        const mockConnectedSite = { name: "test", accessKey: { public_key: "publicKey" } } as ConnectedSite;
+        const mockSites: ConnectedSite[] = [mockConnectedSite, mockConnectedSite, mockConnectedSite];
 
         render(<ConnectedSitesList sites={mockSites} />);
 


### PR DESCRIPTION
# [TA-1230] Refactor ConnectedSite component

## Tasks

- [[TA-1230] Refactor ConnectedSite component](https://www.notion.so/Refactor-ConnectedSite-component-8189015b8b884d7596b2d38ba75d0f2e?pvs=4)

## Changes

- refactor on `Actionable`(`Button` action to `IconButton` due to design changes)
- `ConnectedSitesModal` change to `CardNavigatorModal` (design changes)
- `ConnectedSite` props updated to pass accessKey to `DisconnectSiteModal` (next PR)
- updated tests + common to changes
