### PR TITLE
[TA-1237] SignerId missmatch error

### DIFF
--- a/src/config/configs/config.dev.json
+++ b/src/config/configs/config.dev.json
@@ -11,7 +11,7 @@
     },
     "signerFeature": {
         "enabled": true,
-        "backendUrl": "http://170.20.10.10:3001",
+        "backendUrl": "http://localhost:3001",
         "dAppLogoFallback": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/d57a615b-b77f-487d-95ee-714e659cb8a3.png",
         "recommendedDApps": [
             {

--- a/src/config/configs/config.dev.json
+++ b/src/config/configs/config.dev.json
@@ -11,7 +11,7 @@
     },
     "signerFeature": {
         "enabled": true,
-        "backendUrl": "http://localhost:3001",
+        "backendUrl": "http://192.168.1.55:3001",
         "dAppLogoFallback": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/d57a615b-b77f-487d-95ee-714e659cb8a3.png",
         "recommendedDApps": [
             {

--- a/src/config/configs/config.dev.json
+++ b/src/config/configs/config.dev.json
@@ -11,7 +11,7 @@
     },
     "signerFeature": {
         "enabled": true,
-        "backendUrl": "http://localhost:3001",
+        "backendUrl": "http://170.20.10.10:3001",
         "dAppLogoFallback": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/d57a615b-b77f-487d-95ee-714e659cb8a3.png",
         "recommendedDApps": [
             {

--- a/src/config/configs/config.dev.json
+++ b/src/config/configs/config.dev.json
@@ -11,7 +11,7 @@
     },
     "signerFeature": {
         "enabled": true,
-        "backendUrl": "http://192.168.1.55:3001",
+        "backendUrl": "http://localhost:3001",
         "dAppLogoFallback": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/d57a615b-b77f-487d-95ee-714e659cb8a3.png",
         "recommendedDApps": [
             {

--- a/src/locale/locales/en/errors.json
+++ b/src/locale/locales/en/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/es/errors.json
+++ b/src/locale/locales/es/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Diferente red",
     "networkMismatchDescription": "Esta petición requiere de otra red. Cambia a otra red para poder ver el contenido de la petición.",
     "noConnectedSites": "No estás conectado a ningún dapp con esta cuenta.",
-    "noConnectedSitesDescription": "Parece que no te has conectado aun a ninguna dapp con esta cuenta."
+    "noConnectedSitesDescription": "Parece que no te has conectado aun a ninguna dapp con esta cuenta.",
+    "invalidSigner": "Cuenta inválida",
+    "invalidSignerDescription": "No tienes permisos para realizar esta acción. Por favor, cambia de cuenta."
 }

--- a/src/locale/locales/fr/errors.json
+++ b/src/locale/locales/fr/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/id/errors.json
+++ b/src/locale/locales/id/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/it/errors.json
+++ b/src/locale/locales/it/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/pt/errors.json
+++ b/src/locale/locales/pt/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/ru/errors.json
+++ b/src/locale/locales/ru/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/uk/errors.json
+++ b/src/locale/locales/uk/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/vi/errors.json
+++ b/src/locale/locales/vi/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/zh-CN/errors.json
+++ b/src/locale/locales/zh-CN/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/locale/locales/zh-TW/errors.json
+++ b/src/locale/locales/zh-TW/errors.json
@@ -45,5 +45,7 @@
     "networkMismatch": "Network mismatch",
     "networkMismatchDescription": "This request is expecting a different network. Change the current network to another one to view request details.",
     "noConnectedSites": "No connected sites",
-    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account."
+    "noConnectedSitesDescription": "It seems that you are not connected to any dapp with this account.",
+    "invalidSigner": "Invalid signer account",
+    "invalidSignerDescription": "You have not selected the expected account to sign this request"
 }

--- a/src/module/signer/components/display/ActionsSlider/ActionsSlider.tsx
+++ b/src/module/signer/components/display/ActionsSlider/ActionsSlider.tsx
@@ -5,6 +5,7 @@ import { ActionsSliderRoot } from "./ActionsSlider.styles";
 
 export interface ActionsSliderProps {
     actions: Action[];
+    signerId?: string;
     receiverId?: string;
     metadata?: DAppMetadataDto;
 }

--- a/src/module/signer/components/display/SignRequestDetails/SignRequestDetails.tsx
+++ b/src/module/signer/components/display/SignRequestDetails/SignRequestDetails.tsx
@@ -1,23 +1,13 @@
-import useServiceInstance from "module/wallet/hook/useServiceInstance";
 import ActionsSlider from "../ActionsSlider/ActionsSlider";
 import { SignRequestDetailsProps } from "./SignRequestDetails.types";
 import { Action } from "./actions.types";
-import Error from "module/common/component/display/Error/Error";
 
 const SignRequestDetails = ({ request }: SignRequestDetailsProps): JSX.Element => {
     const requests = request.requests;
 
     const actions = requests[0].actions as Action[];
 
-    const { serviceInstance } = useServiceInstance();
-
-    const address = serviceInstance?.getAddress();
-
-    const isInvalidSigner = requests[0].signerId && requests[0].signerId !== address;
-
-    return isInvalidSigner ? (
-        <Error title="Invalid signer" description="The signer is not valid for this request" />
-    ) : (
+    return (
         <ActionsSlider
             actions={actions}
             receiverId={requests[0].receiverId}

--- a/src/module/signer/components/display/SignRequestDetails/SignRequestDetails.tsx
+++ b/src/module/signer/components/display/SignRequestDetails/SignRequestDetails.tsx
@@ -1,12 +1,30 @@
+import useServiceInstance from "module/wallet/hook/useServiceInstance";
 import ActionsSlider from "../ActionsSlider/ActionsSlider";
 import { SignRequestDetailsProps } from "./SignRequestDetails.types";
 import { Action } from "./actions.types";
+import Error from "module/common/component/display/Error/Error";
 
 const SignRequestDetails = ({ request }: SignRequestDetailsProps): JSX.Element => {
     const requests = request.requests;
+
     const actions = requests[0].actions as Action[];
 
-    return <ActionsSlider actions={actions} receiverId={requests[0].receiverId} metadata={request.dAppMetadata} />;
+    const { serviceInstance } = useServiceInstance();
+
+    const address = serviceInstance?.getAddress();
+
+    const isInvalidSigner = requests[0].signerId && requests[0].signerId !== address;
+
+    return isInvalidSigner ? (
+        <Error title="Invalid signer" description="The signer is not valid for this request" />
+    ) : (
+        <ActionsSlider
+            actions={actions}
+            receiverId={requests[0].receiverId}
+            signerId={requests[0].signerId}
+            metadata={request.dAppMetadata}
+        />
+    );
 };
 
 export default SignRequestDetails;

--- a/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
+++ b/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
@@ -2,7 +2,6 @@ import { Col } from "@peersyst/react-native-components";
 import Button from "module/common/component/input/Button/Button";
 import { useTranslate } from "module/common/hook/useTranslate";
 import { SignatureScaffoldProps } from "./SignatureScaffold.types";
-import SwipeButton from "module/common/component/feedback/SwipeButton/SwipeButton";
 
 const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: SignatureScaffoldProps): JSX.Element => {
     const translate = useTranslate();
@@ -14,9 +13,9 @@ const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: Signatu
                 <Button {...reject} variant="text" onPress={onReject} fullWidth>
                     {translate("reject")}
                 </Button>
-                <SwipeButton {...sign} onSwipe={onSign} fullWidth>
+                <Button {...sign} onPress={onSign} fullWidth>
                     {translate("slideToAccept")}
-                </SwipeButton>
+                </Button>
             </Col>
         </Col>
     );

--- a/src/module/signer/containers/SignerMessageModal/SignerMessageModal.tsx
+++ b/src/module/signer/containers/SignerMessageModal/SignerMessageModal.tsx
@@ -6,9 +6,9 @@ import { SignerModalProps } from "module/signer/hooks/useSignerModal";
 import useGetSignMessageRequest from "module/signer/queries/useGetSignMessageRequest";
 import { useTranslate } from "module/common/hook/useTranslate";
 import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
-import NetworkMismatchError from "module/signer/components/feedback/NetworkMismatchError/NetworkMismatchError";
 import useSignMessage from "module/signer/queries/useSignMessage";
 import LoadingModal from "module/common/component/feedback/LoadingModal/LoadingModal";
+import NetworkMismatchError from "module/signer/components/feedback/NetworkMismatchError/NetworkMismatchError";
 
 const SignerMessageModal = createModal(({ id, ...props }: SignerModalProps): JSX.Element => {
     const translate = useTranslate();

--- a/src/module/signer/containers/SignerRequestModal/SignerRequestModal.tsx
+++ b/src/module/signer/containers/SignerRequestModal/SignerRequestModal.tsx
@@ -3,14 +3,13 @@ import CardSelectModal from "module/common/component/feedback/CardSelectModal/Ca
 import SignRequestDetails from "module/signer/components/display/SignRequestDetails/SignRequestDetails";
 import { SignerModalProps } from "module/signer/hooks/useSignerModal";
 import useGetSignerRequest from "module/signer/queries/useGetSignerRequest";
-import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 import SignatureScaffold from "module/signer/components/layout/SignatureScaffold/SignatureScaffold";
-import NetworkMismatchError from "module/signer/components/feedback/NetworkMismatchError/NetworkMismatchError";
 import useSignRequestActions from "module/signer/queries/useSignRequestActions";
 import LoadingModal from "module/common/component/feedback/LoadingModal/LoadingModal";
 import { useTranslate } from "module/common/hook/useTranslate";
 import { SignerRequestModalProvider } from "./SignerRequestModalContext";
 import { useState } from "react";
+import useHandleSignerRequestError from "./hooks/useHandleSigneRequestError";
 
 const SignerRequestModal = createModal(({ id, ...modalProps }: SignerModalProps): JSX.Element => {
     const translate = useTranslate();
@@ -18,12 +17,11 @@ const SignerRequestModal = createModal(({ id, ...modalProps }: SignerModalProps)
 
     const { data: signerRequest, isLoading } = useGetSignerRequest(id);
 
-    const network = useSelectedNetwork();
-    const matchingNetwork = network === signerRequest?.network;
+    const { error, isError } = useHandleSignerRequestError(signerRequest);
 
     const [signerWalletIndex, setSignerWalletIndex] = useState<number>();
 
-    const { mutate: signRequest, isLoading: isSigning, isError, isSuccess } = useSignRequestActions(signerWalletIndex);
+    const { mutate: signRequest, isLoading: isSigning, isError: isSignError, isSuccess } = useSignRequestActions(signerWalletIndex);
 
     const close = () => hideModal(SignerRequestModal.id);
 
@@ -34,22 +32,22 @@ const SignerRequestModal = createModal(({ id, ...modalProps }: SignerModalProps)
     return (
         <CardSelectModal {...modalProps} title={translate("signRequest")} dismissal="close" style={{ height: "95%" }}>
             <Skeleton loading={isLoading}>
-                {!matchingNetwork ? (
-                    <NetworkMismatchError />
+                {isError ? (
+                    error
                 ) : (
                     <SignerRequestModalProvider value={{ signerWalletIndex, setSignerWalletIndex }}>
                         <SignatureScaffold
                             onSign={handleSign}
                             onReject={handleReject}
-                            sign={{ loading: isSigning, disabled: isSuccess || isError }}
-                            reject={{ loading: isSigning, disabled: isSuccess || isError }}
+                            sign={{ loading: isSigning, disabled: isSuccess || isSignError }}
+                            reject={{ loading: isSigning, disabled: isSuccess || isSignError }}
                         >
                             <SignRequestDetails request={signerRequest!} />
                         </SignatureScaffold>
                         <LoadingModal
                             loading={isSigning}
                             success={isSuccess}
-                            error={isError}
+                            error={isSignError}
                             successMessage={translate("requestSignedSuccessfully")}
                             onClose={close}
                         />

--- a/src/module/signer/containers/SignerRequestModal/hooks/useHandleSigneRequestError.tsx
+++ b/src/module/signer/containers/SignerRequestModal/hooks/useHandleSigneRequestError.tsx
@@ -10,7 +10,12 @@ interface SignerRequestError {
     condition: boolean;
 }
 
-export default function useHandleSignerRequestError(signerRequest: SignerRequestDto | undefined) {
+interface useHandleSignerRequestErrorReturn {
+    signerRequestError: JSX.Element | undefined;
+    isSignerRequestError: boolean;
+}
+
+export default function useHandleSignerRequestError(signerRequest: SignerRequestDto | undefined): useHandleSignerRequestErrorReturn {
     const translateError = useTranslate("error");
     const { serviceInstance } = useServiceInstance();
     const network = useSelectedNetwork();
@@ -36,7 +41,7 @@ export default function useHandleSignerRequestError(signerRequest: SignerRequest
     const isError = errors.find((error) => error.condition);
 
     return {
-        error: isError ? <Error title={isError?.title} description={isError?.description} /> : undefined,
-        isError: !!isError,
+        signerRequestError: isError ? <Error title={isError?.title} description={isError?.description} /> : undefined,
+        isSignerRequestError: !!isError,
     };
 }

--- a/src/module/signer/containers/SignerRequestModal/hooks/useHandleSigneRequestError.tsx
+++ b/src/module/signer/containers/SignerRequestModal/hooks/useHandleSigneRequestError.tsx
@@ -1,0 +1,42 @@
+import { SignerRequestDto } from "module/api/service";
+import { useTranslate } from "module/common/hook/useTranslate";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
+import useServiceInstance from "module/wallet/hook/useServiceInstance";
+import Error from "module/common/component/display/Error/Error";
+
+interface SignerRequestError {
+    title: string;
+    description: string;
+    condition: boolean;
+}
+
+export default function useHandleSignerRequestError(signerRequest: SignerRequestDto | undefined) {
+    const translateError = useTranslate("error");
+    const { serviceInstance } = useServiceInstance();
+    const network = useSelectedNetwork();
+
+    const matchingNetwork = network === signerRequest?.network;
+
+    const address = serviceInstance?.getAddress();
+    const isValidSigner = signerRequest?.requests[0].signerId === address || signerRequest?.requests[0].signerId === undefined;
+
+    const errors: SignerRequestError[] = [
+        {
+            title: translateError("networkMismatch"),
+            description: translateError("networkMismatchDescription"),
+            condition: !matchingNetwork,
+        },
+        {
+            title: translateError("invalidSigner"),
+            description: translateError("invalidSignerDescription"),
+            condition: !isValidSigner,
+        },
+    ];
+
+    const isError = errors.find((error) => error.condition);
+
+    return {
+        error: isError ? <Error title={isError?.title} description={isError?.description} /> : undefined,
+        isError: !!isError,
+    };
+}


### PR DESCRIPTION
# [TA-1237] SignerId missmatch error

## Tasks

- [[TA-1237] SignerId missmatch error](https://www.notion.so/SignerId-missmatch-error-6c1fc095e94a4103acb2cdfb0bdcb605?pvs=4)

## Changes

- `useHandleSignerRequestError` hook to handle possible errors (such as `network` or `signerId` mismatches)
- Updated `SignerRequestModal` with error handling
- updated errors locale
