### PR TITLE
[TA-1250] Handle inactive accounts

### DIFF
--- a/src/locale/locales/en/common.json
+++ b/src/locale/locales/en/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/es/common.json
+++ b/src/locale/locales/es/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "Categorías de dApps",
     "disconnectDApp": "Para confirmar la desconexión de la dApp, por favor, pulse el botón de desconectar.",
     "connectedWith": "Conectado con {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "Con permisos:",
+    "signerChangeAccount": "No puede firmar esta solicitud con la cuenta seleccionada porque no está activada. Por favor, seleccione otra cuenta."
 }

--- a/src/locale/locales/es/common.json
+++ b/src/locale/locales/es/common.json
@@ -297,7 +297,7 @@
     "notTransferTokensPermission": "No permite que la aplicación transfiera tokens",
     "contract": "Contracto",
     "networkFeeAllowance": "Comisión de red",
-    "networkFeeAllowanceDescription": "La aplicación tendrá permiso para gastar hasta {{amount}} NEAR en gastos de red incurridos durante su uso.",
+    "networkFeeAllowanceDescription": "La aplicación tendrá permiso para gastar hasta {{amount}} en gastos de red incurridos durante su uso.",
     "signWith": "Firmar con",
     "rejectConnection": "Rechazar conexión",
     "slideToAccept": "Deslizar para aceptar",

--- a/src/locale/locales/fr/common.json
+++ b/src/locale/locales/fr/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/id/common.json
+++ b/src/locale/locales/id/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/it/common.json
+++ b/src/locale/locales/it/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/pt/common.json
+++ b/src/locale/locales/pt/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/ru/common.json
+++ b/src/locale/locales/ru/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/uk/common.json
+++ b/src/locale/locales/uk/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/vi/common.json
+++ b/src/locale/locales/vi/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/zh-CN/common.json
+++ b/src/locale/locales/zh-CN/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/locale/locales/zh-TW/common.json
+++ b/src/locale/locales/zh-TW/common.json
@@ -308,5 +308,6 @@
     "dAppCategories": "dApp categories",
     "disconnectDApp": "To confirm that you want to disconnect the dApp, please press the Disconnect button again.",
     "connectedWith": "Connected with {{name}}:",
-    "withPermissions": "With permissions:"
+    "withPermissions": "With permissions:",
+    "signerChangeAccount": "You cannot sign this request with the selected account because it is not activated. Please, select another account."
 }

--- a/src/module/signer/components/display/SignMessageDetails/SignMessageDetails.tsx
+++ b/src/module/signer/components/display/SignMessageDetails/SignMessageDetails.tsx
@@ -4,6 +4,7 @@ import { ConnectIcon } from "icons";
 import ActionDetailField from "../ActionDetailField/ActionDetailField";
 import Container from "module/common/component/display/Container/Container";
 import { useTranslate } from "module/common/hook/useTranslate";
+import SignerWalletSelector from "module/signer/containers/SignerWalletSelector/SignerWalletSelector";
 
 const SignMessageDetails = ({ receiver, message, metadata }: SignMessageDetailsProps): JSX.Element => {
     const previewProps = metadata ? { dAppPreview: { logoUrl: metadata.logoUrl, Icon: ConnectIcon } } : undefined;
@@ -19,6 +20,7 @@ const SignMessageDetails = ({ receiver, message, metadata }: SignMessageDetailsP
             <Container>
                 <ActionDetailField label={translate("message")} description={message} />
             </Container>
+            <SignerWalletSelector />
         </ActionDetailsScaffold>
     );
 };

--- a/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
+++ b/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
@@ -2,20 +2,41 @@ import { Col } from "@peersyst/react-native-components";
 import Button from "module/common/component/input/Button/Button";
 import { useTranslate } from "module/common/hook/useTranslate";
 import { SignatureScaffoldProps } from "./SignatureScaffold.types";
+import Typography from "module/common/component/display/Typography/Typography";
+import { useSignerWalletIndex } from "module/signer/containers/SignerRequestModal/SignerRequestModalContext";
+import useIsAccountActive from "module/signer/queries/useIsActiveAccount";
 
-const SignatureScaffold = ({ children, onSign, onReject, sign, reject }: SignatureScaffoldProps): JSX.Element => {
+const SignatureScaffold = ({ children, onSign, onReject, sign = {}, reject = {} }: SignatureScaffoldProps): JSX.Element => {
+    const { disabled: isSigningDisabled, ...restSign } = sign;
+    const { disabled: isRejectingDisabled, ...restReject } = reject;
+
     const translate = useTranslate();
+
+    const [signerWalletIndex] = useSignerWalletIndex();
+
+    const { data: isActiveAccount, isLoading: isActiveAccountLoading } = useIsAccountActive(signerWalletIndex);
 
     return (
         <Col flex={1} justifyContent="space-between">
             <Col flex={1}>{children}</Col>
             <Col gap={12} style={{ marginTop: 20 }}>
-                <Button {...reject} variant="text" onPress={onReject} fullWidth>
+                <Button
+                    {...restReject}
+                    variant="text"
+                    onPress={onReject}
+                    fullWidth
+                    disabled={isRejectingDisabled || isActiveAccountLoading || !isActiveAccount}
+                >
                     {translate("reject")}
                 </Button>
-                <Button {...sign} onPress={onSign} fullWidth>
+                <Button {...restSign} onPress={onSign} fullWidth disabled={isSigningDisabled || isActiveAccountLoading || !isActiveAccount}>
                     {translate("slideToAccept")}
                 </Button>
+                {!isActiveAccount && (
+                    <Typography variant="body4Regular" textAlign="center">
+                        {translate("signerChangeAccount")}
+                    </Typography>
+                )}
             </Col>
         </Col>
     );

--- a/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
+++ b/src/module/signer/components/layout/SignatureScaffold/SignatureScaffold.tsx
@@ -3,7 +3,7 @@ import Button from "module/common/component/input/Button/Button";
 import { useTranslate } from "module/common/hook/useTranslate";
 import { SignatureScaffoldProps } from "./SignatureScaffold.types";
 import Typography from "module/common/component/display/Typography/Typography";
-import { useSignerWalletIndex } from "module/signer/containers/SignerRequestModal/SignerRequestModalContext";
+import { useSignerWalletIndex } from "module/signer/context/SignerModalContext";
 import useIsAccountActive from "module/signer/queries/useIsActiveAccount";
 
 const SignatureScaffold = ({ children, onSign, onReject, sign = {}, reject = {} }: SignatureScaffoldProps): JSX.Element => {

--- a/src/module/signer/containers/SignerMessageModal/SignerMessageModal.tsx
+++ b/src/module/signer/containers/SignerMessageModal/SignerMessageModal.tsx
@@ -9,17 +9,21 @@ import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 import useSignMessage from "module/signer/queries/useSignMessage";
 import LoadingModal from "module/common/component/feedback/LoadingModal/LoadingModal";
 import NetworkMismatchError from "module/signer/components/feedback/NetworkMismatchError/NetworkMismatchError";
+import { SignerModalProvider } from "../../context/SignerModalContext";
+import { useState } from "react";
 
 const SignerMessageModal = createModal(({ id, ...props }: SignerModalProps): JSX.Element => {
     const translate = useTranslate();
     const { hideModal } = useModal();
+
+    const [signerWalletIndex, setSignerWalletIndex] = useState<number>();
 
     const { data: signMessageRequest, isLoading } = useGetSignMessageRequest(id);
 
     const network = useSelectedNetwork();
     const matchingNetwork = network === signMessageRequest?.network;
 
-    const { mutate: signMessage, isLoading: isSigning, isError, isSuccess } = useSignMessage();
+    const { mutate: signMessage, isLoading: isSigning, isError, isSuccess } = useSignMessage(signerWalletIndex);
 
     const close = () => hideModal(SignerMessageModal.id);
 
@@ -33,7 +37,7 @@ const SignerMessageModal = createModal(({ id, ...props }: SignerModalProps): JSX
                 {!matchingNetwork ? (
                     <NetworkMismatchError />
                 ) : (
-                    <>
+                    <SignerModalProvider value={{ signerWalletIndex, setSignerWalletIndex }}>
                         <SignatureScaffold
                             onSign={handleSign}
                             onReject={handleReject}
@@ -53,7 +57,7 @@ const SignerMessageModal = createModal(({ id, ...props }: SignerModalProps): JSX
                             successMessage={translate("messageSignedSuccessfully")}
                             onExited={close}
                         />
-                    </>
+                    </SignerModalProvider>
                 )}
             </Skeleton>
         </CardSelectModal>

--- a/src/module/signer/containers/SignerRequestModal/SignerRequestModal.tsx
+++ b/src/module/signer/containers/SignerRequestModal/SignerRequestModal.tsx
@@ -40,7 +40,10 @@ const SignerRequestModal = createModal(({ id, ...modalProps }: SignerModalProps)
                             onSign={handleSign}
                             onReject={handleReject}
                             sign={{ loading: isSigning, disabled: isSuccess || isSignError }}
-                            reject={{ loading: isSigning, disabled: isSuccess || isSignError }}
+                            reject={{
+                                loading: isSigning,
+                                disabled: isSuccess || isSignError,
+                            }}
                         >
                             <SignRequestDetails request={signerRequest!} />
                         </SignatureScaffold>

--- a/src/module/signer/containers/SignerRequestModal/SignerRequestModal.tsx
+++ b/src/module/signer/containers/SignerRequestModal/SignerRequestModal.tsx
@@ -7,7 +7,7 @@ import SignatureScaffold from "module/signer/components/layout/SignatureScaffold
 import useSignRequestActions from "module/signer/queries/useSignRequestActions";
 import LoadingModal from "module/common/component/feedback/LoadingModal/LoadingModal";
 import { useTranslate } from "module/common/hook/useTranslate";
-import { SignerRequestModalProvider } from "./SignerRequestModalContext";
+import { SignerModalProvider } from "../../context/SignerModalContext";
 import { useState } from "react";
 import useHandleSignerRequestError from "./hooks/useHandleSigneRequestError";
 
@@ -35,7 +35,7 @@ const SignerRequestModal = createModal(({ id, ...modalProps }: SignerModalProps)
                 {isSignerRequestError ? (
                     signerRequestError
                 ) : (
-                    <SignerRequestModalProvider value={{ signerWalletIndex, setSignerWalletIndex }}>
+                    <SignerModalProvider value={{ signerWalletIndex, setSignerWalletIndex }}>
                         <SignatureScaffold
                             onSign={handleSign}
                             onReject={handleReject}
@@ -54,7 +54,7 @@ const SignerRequestModal = createModal(({ id, ...modalProps }: SignerModalProps)
                             successMessage={translate("requestSignedSuccessfully")}
                             onClose={close}
                         />
-                    </SignerRequestModalProvider>
+                    </SignerModalProvider>
                 )}
             </Skeleton>
         </CardSelectModal>

--- a/src/module/signer/containers/SignerWalletSelector/SignerWalletSelector.tsx
+++ b/src/module/signer/containers/SignerWalletSelector/SignerWalletSelector.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from "module/common/hook/useTranslate";
 import WalletSelector from "module/wallet/component/input/WalletSelector/WalletSelector";
 
-import { useSignerWalletIndex } from "../SignerRequestModal/SignerRequestModalContext";
+import { useSignerWalletIndex } from "../../context/SignerModalContext";
 
 const SignerWalletSelector = (): JSX.Element => {
     const translate = useTranslate();

--- a/src/module/signer/context/SignerModalContext.ts
+++ b/src/module/signer/context/SignerModalContext.ts
@@ -1,18 +1,18 @@
 import { createContext, useContext } from "react";
 
-export interface SignRequestState {
+export interface SignState {
     signerWalletIndex: number | undefined;
     setSignerWalletIndex: (index: number) => void;
 }
 
-export const SignerRequestModalContext = createContext<SignRequestState>({
+export const SignerModalContext = createContext<SignState>({
     signerWalletIndex: undefined,
     setSignerWalletIndex: () => undefined,
 });
-export const SignerRequestModalProvider = SignerRequestModalContext.Provider;
-export const SignerRequestModalConsumer = SignerRequestModalContext.Consumer;
+export const SignerModalProvider = SignerModalContext.Provider;
+export const SignerModalConsumer = SignerModalContext.Consumer;
 
 export const useSignerWalletIndex = (): [number | undefined, (index: number) => void] => {
-    const { signerWalletIndex, setSignerWalletIndex } = useContext(SignerRequestModalContext);
+    const { signerWalletIndex, setSignerWalletIndex } = useContext(SignerModalContext);
     return [signerWalletIndex, setSignerWalletIndex];
 };

--- a/src/module/signer/queries/useIsActiveAccount.ts
+++ b/src/module/signer/queries/useIsActiveAccount.ts
@@ -13,6 +13,8 @@ export default function useIsAccountActive(walletIndex?: number) {
         },
         {
             enabled: !!serviceInstance,
+            cacheTime: 0,
+            staleTime: 0,
         },
     );
 }

--- a/src/module/signer/queries/useIsActiveAccount.ts
+++ b/src/module/signer/queries/useIsActiveAccount.ts
@@ -1,0 +1,18 @@
+import useServiceInstance from "module/wallet/hook/useServiceInstance";
+import Queries from "../../../query/queries";
+import { useQuery } from "react-query";
+
+export default function useIsAccountActive(walletIndex?: number) {
+    const { serviceInstance, index, network } = useServiceInstance(walletIndex);
+
+    return useQuery(
+        [Queries.ACCOUNT_IS_ACTIVE, index, network],
+        async () => {
+            const accountId = await serviceInstance.getAccountId();
+            return await serviceInstance.accountExists(accountId);
+        },
+        {
+            enabled: !!serviceInstance,
+        },
+    );
+}

--- a/src/module/signer/queries/useSignMessage.ts
+++ b/src/module/signer/queries/useSignMessage.ts
@@ -8,8 +8,8 @@ interface UseSignMessageParams {
     receiver: string;
 }
 
-export default function useSignMessage() {
-    const { serviceInstance } = useServiceInstance();
+export default function useSignMessage(walletIndex?: number) {
+    const { serviceInstance } = useServiceInstance(walletIndex);
 
     return useMutation(({ id, message, receiver }: UseSignMessageParams) =>
         SignerRequestService.signMessageRequest(id, {

--- a/src/query/queries.ts
+++ b/src/query/queries.ts
@@ -17,6 +17,7 @@ enum Queries {
     IS_DAPP_CONNECTED = "is-dapp-connected",
     RECOMMENDED_DAPPS = "recommended-dapps",
     GET_CONNECTED_SITE_LOGO = "get-connected-site-logo",
+    ACCOUNT_IS_ACTIVE = "account-is-active",
 }
 
 export default Queries;


### PR DESCRIPTION
# [TA-1250] Handle inactive accounts

## Tasks

- [[TA-1250] Handle inactive accounts](https://www.notion.so/Handle-inactive-accounts-d1143b4c627c4a78857e187d829a260d?pvs=4)


## Changes

- `useIsActiveAccount` query to check if an account is activated or not
- `SignatureScaffold` handles account activation
- renaming on `SignerModalContext` (due to usage on both modals)
- locale updates

![IMG_0610](https://github.com/Peersyst/near-mobile-wallet/assets/68080871/f72cb60b-cba2-469c-a291-da40e93ba80d)
