### PR TITLE
[TA-1368] Dialog not loading or disabled buttons when disconnect

### DIFF
--- a/src/config/configs/config.staging.json
+++ b/src/config/configs/config.staging.json
@@ -1,5 +1,5 @@
 {
-    "enableChangeNetwork": false,
+    "enableChangeNetwork": true,
     "enableBuy": true,
     "transak": {
         "apiKey": "f2d9a722-cac0-4bea-bdfc-2560d65f1a1e",

--- a/src/module/signer/components/feedback/DisconnectableDApp/DisconnectableDApp.tsx
+++ b/src/module/signer/components/feedback/DisconnectableDApp/DisconnectableDApp.tsx
@@ -1,42 +1,27 @@
 import { useTranslate } from "module/common/hook/useTranslate";
 import DApp from "../../display/DApp/DApp";
 import { DisconnectableDAppProps } from "./DisconnectableDApp.types";
-import useCancelableDialog from "module/common/hook/useCancelableDialog";
 import { DisconnectableDAppRoot } from "./DisconnectableDApp.styles";
 import useIsDAppConnected from "module/signer/queries/useIsDAppConnected";
 import useDisconnectSmartContract from "module/signer/queries/useDisconnectSmartContract";
+import useDisconnectDAppDialog from "./hooks/useDisconnectDAppDialog";
 
 const DisconnectableDApp = ({ dapp }: DisconnectableDAppProps): JSX.Element => {
     const translate = useTranslate();
 
     const { data: connected, isLoading } = useIsDAppConnected(dapp.contractId);
-
-    const { showCancelableDialog, hideCancelableDialog: hideDialog } = useCancelableDialog();
-    const { mutate: disconnectSmartContract, isLoading: isDeleting } = useDisconnectSmartContract({ onSuccess: hideDialog });
+    const { mutate: disconnectSmartContract, isLoading: isDeleting } = useDisconnectSmartContract();
 
     const handleDisconnect = () => {
-        disconnectSmartContract(dapp.contractId);
+        disconnectSmartContract(dapp.contractId, { onSuccess: hideDialog });
     };
 
-    const handleSwipeAction = () => {
-        showCancelableDialog({
-            title: translate("disconnect"),
-            content: translate("confirmDisconnect"),
-            buttons: [
-                {
-                    action: handleDisconnect,
-                    text: translate("disconnect"),
-                    type: "destructive",
-                    disabled: isDeleting,
-                    loading: isDeleting,
-                },
-            ],
-        });
-    };
+    const { showDialog, hideDialog, dialog } = useDisconnectDAppDialog({ onDisconnect: handleDisconnect, disconnecting: isDeleting });
 
     return (
-        <DisconnectableDAppRoot onSwipedRightAction={handleSwipeAction} swipedRightAction={translate("disconnect")} enabled={connected}>
+        <DisconnectableDAppRoot onSwipedRightAction={showDialog} swipedRightAction={translate("disconnect")} enabled={connected}>
             <DApp dapp={dapp} connected={connected} loading={isLoading} />
+            {dialog}
         </DisconnectableDAppRoot>
     );
 };

--- a/src/module/signer/components/feedback/DisconnectableDApp/hooks/useDisconnectDAppDialog.tsx
+++ b/src/module/signer/components/feedback/DisconnectableDApp/hooks/useDisconnectDAppDialog.tsx
@@ -1,0 +1,46 @@
+import { Dialog } from "@peersyst/react-native-components";
+import { useTranslate } from "module/common/hook/useTranslate";
+import { useState } from "react";
+
+interface UseDisconnectDAppDialogProps {
+    onDisconnect?: () => void;
+    disconnecting?: boolean;
+    onCancel?: () => void;
+}
+
+export default function useDisconnectDAppDialog({ onDisconnect, onCancel, disconnecting = false }: UseDisconnectDAppDialogProps) {
+    const translate = useTranslate();
+
+    const [openDialog, setOpenDialog] = useState(false);
+
+    const hideDialog = () => setOpenDialog(false);
+
+    const handleCancel = () => {
+        onCancel?.();
+        hideDialog();
+    };
+
+    const dialogButtons = [
+        {
+            action: onDisconnect,
+            text: translate("disconnect"),
+            type: "destructive",
+            loading: disconnecting,
+        },
+        {
+            action: handleCancel,
+            text: translate("cancel"),
+            type: "default",
+            variant: "text",
+            disabled: disconnecting,
+        },
+    ];
+
+    return {
+        showDialog: () => setOpenDialog(true),
+        hideDialog,
+        dialog: (
+            <Dialog open={openDialog} title={translate("disconnect")} content={translate("confirmDisconnect")} buttons={dialogButtons} />
+        ),
+    };
+}


### PR DESCRIPTION
# [TA-1368] Dialog not loading or disabled buttons when disconnect

## Tasks

- [[TA-1368] Dialog not loading or disabled buttons when disconnect](https://www.notion.so/Dialog-not-loading-or-disabled-buttons-when-disconnect-87526148859b4625a80108d03838b76d?pvs=4)

#363 

## Changes

- `useDisconnectDAppDialog` to control dialog because `loading` & `disabled` props not working with `useDialog` hook
- `config.staging` enabledChangeNetwork to test signature with testnet network
