### PR TITLE
[TA-1369] Check Deep linking render

### DIFF
--- a/src/module/home/screen/HomeScreen.tsx
+++ b/src/module/home/screen/HomeScreen.tsx
@@ -4,13 +4,15 @@ import MainGradientScreen from "module/main/component/layout/MainGradientScreen/
 import useShowSignerRequest from "module/signer/hooks/useShowSignerRequest";
 
 import { useEffect } from "react";
+import { useAppState } from "@react-native-community/hooks";
 
 const HomeScreen = (): JSX.Element => {
+    const appState = useAppState();
     const showSignerRequest = useShowSignerRequest();
 
     useEffect(() => {
-        showSignerRequest();
-    }, []);
+        if (appState === "active") showSignerRequest();
+    }, [appState]);
 
     return (
         <MainGradientScreen>


### PR DESCRIPTION
# [TA-1369] Check Deep linking render

## Tasks

- [[TA-1369] Check Deep linking render](https://www.notion.so/Check-Deep-linking-render-7731e8a7a207433f857208bf7417ed83?pvs=4)


## Changes

- Updated useEffect in HomeScreen to trigger `showSignerRequest` when appState is `active`

### Notes

**Previous problem**: When the app was not open or in background deep linking was working fine. But if the app was in background state and a QR code was scanned and the user was redirected to the app, the SignerModal was not showing

https://github.com/Peersyst/near-mobile-wallet/assets/68080871/d566c536-463e-460d-92c5-03542c55f0a3

