### PR TITLE
[TA-1401] Withdraw staking crashes the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "@react-navigation/native-stack": "^6.5.0",
         "@types/color": "^3.0.3",
         "big-integer": "^1.6.51",
-        "bn.js": "^5.2.1",
         "buffer": "^6.0.3",
         "color": "^4.2.3",
         "core-js": "^3.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,7 +3415,7 @@ blueimp-md5@^2.10.0:
   resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.19.0.tgz#b53feea5498dcb53dc6ec4b823adb84b729c4af0"
   integrity sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==
 
-bn.js@5.2.1, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0, bn.js@^5.2.1:
+bn.js@5.2.1, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==


### PR DESCRIPTION
# [TA-1401] Withdraw staking crashes the app

## Tasks

- [[TA-1401] Withdraw staking crashes the app](https://www.notion.so/Withdraw-staking-crashes-the-app-9d55034de6874547adc31e4cc0ee885c?pvs=4)

## Changes

- removed `bn.js` version dependency (5.2.1 version was crashing on `useGetWithdrawValidators` -> `BalanceOperations)` to default version `5.2.0`
