### PR TITLE
[TA-2166] Support .tg addresses

### DIFF
--- a/src/module/sdk/NearSdkService/NearSdkService.ts
+++ b/src/module/sdk/NearSdkService/NearSdkService.ts
@@ -249,8 +249,8 @@ export class NearSDKService {
             const splittedNameId = nameId.split(".");
             if (splittedNameId.length > 1) {
                 const suffix = splittedNameId.pop();
-                const validSuffix = network === Chains.MAINNET ? "near" : "testnet";
-                if (suffix !== validSuffix) return false;
+                const invalidSuffix = network === Chains.MAINNET ? "testnet" : "near";
+                if (suffix === invalidSuffix) return false;
             }
         }
         return nameId.length >= 2 && nameId.length <= 64 && NearSDKService.nameRegex.test(nameId);

--- a/test/unit/src/module/transaction/component/input/AddressTextField.spec.tsx
+++ b/test/unit/src/module/transaction/component/input/AddressTextField.spec.tsx
@@ -15,9 +15,9 @@ describe("AddressTextField Test", () => {
         expect(screen.getByTestId("ActivityIndicator")).toBeDefined();
 
         //Update the input because of an invalid name
-        fireEvent.changeText(input, "manolo.testnut");
+        fireEvent.changeText(input, "m");
         expect(screen.getByTestId("ActivityIndicator")).toBeDefined();
-        expect(input.props.value).toBe("manolo.testnut");
+        expect(input.props.value).toBe("m");
         await waitFor(() => {
             screen.getByText(translate("invalid_address", { ns: "error" }));
         });


### PR DESCRIPTION
# Support .tg addresses

## Changes

- `NearSdkService` instead of checking that only `mainnet` or `testnet` is valid, check that `testnet` is not using in mainnet and viceversa. This way, we support all suffixes.
