### PR TITLE
[TA-2169] Swipe DApp to disconnect

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { Suspense } from "@peersyst/react-native-components";
 import { useRecoilValue } from "recoil";
 import settingsState from "module/settings/state/SettingsState";
 import { Platform, UIManager } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 import "module/api/OpenApiConfig";
 
@@ -30,8 +31,12 @@ const App = (): JSX.Element => {
 
 export default function Root(): JSX.Element {
     return (
-        <Providers>
-            <App />
-        </Providers>
+        // `GestureHandlerRootView` enables all `react-native-gesture-handler` features.
+        // For example, `Swipeable` from `react-native-gesture-handler` will not trigger `Touchable`'s `onPress`.
+        <GestureHandlerRootView style={{ flex: 1 }}>
+            <Providers>
+                <App />
+            </Providers>
+        </GestureHandlerRootView>
     );
 }

--- a/src/module/common/component/feedback/Actionable/Actionable.tsx
+++ b/src/module/common/component/feedback/Actionable/Actionable.tsx
@@ -4,19 +4,17 @@ import { TouchableOpacity } from "react-native";
 import { ActionRoot } from "./Actionable.styles";
 
 const Actionable = ({ action: actionProp, onAction, position = "right", children, ...rest }: ActionableProps): JSX.Element => {
-    const action: JSX.Element = (
-        <TouchableOpacity activeOpacity={0.6} onPress={onAction}>
-            <ActionRoot>{actionProp}</ActionRoot>
-        </TouchableOpacity>
-    );
+    const action: JSX.Element = <ActionRoot>{actionProp}</ActionRoot>;
 
     const [firstItem, secondItem] = position === "left" ? [action, children] : [children, action];
 
     return (
-        <Row justifyContent="center" alignItems="center" {...rest}>
-            {firstItem}
-            {secondItem}
-        </Row>
+        <TouchableOpacity activeOpacity={0.6} onPress={onAction}>
+            <Row justifyContent="center" alignItems="center" {...rest}>
+                {firstItem}
+                {secondItem}
+            </Row>
+        </TouchableOpacity>
     );
 };
 

--- a/src/module/signer/components/display/DApp/DApp.tsx
+++ b/src/module/signer/components/display/DApp/DApp.tsx
@@ -2,7 +2,10 @@ import { DAppProps } from "./DApp.types";
 import { DAppRoot, DAppLogo, DAppTag, DAppLinkIcon } from "./DApp.styles";
 import { Col, Row, Skeleton, Typography } from "@peersyst/react-native-components";
 import DAppStatus from "../DAppStatus/DAppStatus";
-import { Linking, TouchableOpacity } from "react-native";
+import { Linking } from "react-native";
+// TouchableOpacity from react-native-gesture-handler handles touches with Swipeable.
+// Otherwise, Swipeable triggers the `onPress`
+import { TouchableOpacity } from "react-native-gesture-handler";
 
 const DApp = ({ dapp, connected = false, loading = false }: DAppProps): JSX.Element => {
     const { name, description, logoUrl, url, tag } = dapp;


### PR DESCRIPTION
# Swipe DApp to disconnect

## Changes

- Add `GestureHandlerRootView` to `index.tsx` to enable all `react-native-gesture-handler` features. Such as `Swipeable` not triggering `Touchable` `onPress`
- Make all the `Actionable` pressable instead of the `action` exclusively
- Change `TouchableOpacity` import in `DApp` from `react-native` to `react-native-gesture-handler`
