### PR TITLE
[TA-2201] Fix recover wallets

### DIFF
--- a/src/module/wallet/hook/useImportWallets.ts
+++ b/src/module/wallet/hook/useImportWallets.ts
@@ -14,16 +14,15 @@ export default function useImportWallets() {
         const parsedMnemonic = mnemonic?.join(" ");
         const { wallets } = await WalletController.importWallets(network, pin, parsedMnemonic, privateKey);
 
-        if (wallets.length > 0) {
-            setWalletState((state) => {
-                return {
-                    ...state,
-                    wallets: [...state.wallets, ...wallets],
-                    hasWallet: true,
-                    isAuthenticated: true,
-                };
-            });
-        }
+        setWalletState((state) => {
+            return {
+                ...state,
+                wallets: [...state.wallets, ...wallets],
+                hasWallet: true,
+                isAuthenticated: true,
+            };
+        });
+
         return wallets;
     };
     return importWallets;

--- a/src/module/wallet/hook/useRecoverWallets.ts
+++ b/src/module/wallet/hook/useRecoverWallets.ts
@@ -8,14 +8,14 @@ export default function useRecoverWallets() {
     const recoverWallets = async (network: NetworkType): Promise<boolean> => {
         const { wallets } = await WalletController.recoverWallets(network);
         const hasWallets = wallets.length !== 0;
-        if (hasWallets) {
-            setWalletState((state) => ({
-                ...state,
-                selectedWallet: 0,
-                hasWallet: true,
-                wallets: wallets,
-            }));
-        }
+
+        setWalletState((state) => ({
+            ...state,
+            selectedWallet: 0,
+            hasWallet: true,
+            wallets: wallets,
+        }));
+
         return hasWallets;
     };
     return recoverWallets;

--- a/src/module/wallet/utils/WalletController.ts
+++ b/src/module/wallet/utils/WalletController.ts
@@ -167,9 +167,6 @@ export default new (class WalletController {
         //Has all the privateKeys and walletIds that point into the oldStorageWallets
         const walletGroups = secureStorage?.[network] || [];
 
-        //Does not have any previous wallet
-        if (storageWallets.length === 0 || walletGroups.length === 0) return { wallets: [] };
-
         const mainPrivateKey = this.parsePrivateKey(secureStorage?.mainPrivateKey || ""); //If has previous wallets, it has a mainPrivateKey
 
         const { newWallets, newWalletGroups, deletedIds, hasNewAccounts } = await this.checkWallets({


### PR DESCRIPTION
# Fix recover wallets

## Changes

- Remove checks when having 0 wallets in a mnemonic (not possible nevertheless).
- When recovering wallets after deinstalation, old wallets are recovered sucessfully but the following warning appears: `"Corrupted storage: Wallet not found. WalletId: ", walletId`
