### PR TITLE
[TA-2249] Fix token decimals display

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@react-navigation/native-stack": "^6.5.0",
         "@types/color": "^3.0.3",
         "big-integer": "^1.6.51",
+        "bignumber.js": "^9.1.2",
         "borsh": "^1.0.0",
         "buffer": "^6.0.3",
         "color": "^4.2.3",

--- a/src/module/sdk/utils/BalanceOperations.ts
+++ b/src/module/sdk/utils/BalanceOperations.ts
@@ -16,8 +16,8 @@ export class BalanceOperations {
         return new BN(a).gte(new BN(b));
     }
     static BNDevide(a: string, b: string): string {
-        const numerator = BigInt(a);
-        const denominator = BigInt(b);
+        const numerator = parseFloat(a);
+        const denominator = parseFloat(b);
         return (numerator / denominator).toString();
     }
     static BNMultiply(a: string, b: string): string {

--- a/src/module/sdk/utils/BalanceOperations.ts
+++ b/src/module/sdk/utils/BalanceOperations.ts
@@ -28,6 +28,9 @@ export class BalanceOperations {
     static BNAdd(a: string, b: string): string {
         return BigNumber(a).plus(BigNumber(b)).toString();
     }
+    static BNShift(a: string, b: number): string {
+        return BigNumber(a).shiftedBy(b).toString();
+    }
 
     // Number operations
     /**

--- a/src/module/sdk/utils/BalanceOperations.ts
+++ b/src/module/sdk/utils/BalanceOperations.ts
@@ -1,35 +1,33 @@
 import { convertNearToYocto, convertYoctoToNear } from "./near.utils";
-import BigNumber from "bignumber.js";
 import BN from "bn.js";
 
 export class BalanceOperations {
     //Big number operations
     static BNToString(bn: string): string {
-        return BigNumber(bn).toString();
+        return new BN(bn).toString();
     }
     static BNExp(base: number, exponent: number): string {
-        return new BigNumber(base).pow(BigNumber(exponent)).toString();
+        return new BN(base).pow(new BN(exponent)).toString();
     }
     static BNIsBigger(a: string, b: string): boolean {
-        return BigNumber(a).gt(BigNumber(b));
+        return new BN(a).gt(new BN(b));
     }
     static BNIsBiggerOrEqual(a: string, b: string): boolean {
-        return BigNumber(a).gte(BigNumber(b));
+        return new BN(a).gte(new BN(b));
     }
     static BNDivide(a: string, b: string): string {
-        return BigNumber(a).dividedBy(BigNumber(b)).toString();
+        const numerator = BigInt(a);
+        const denominator = BigInt(b);
+        return (numerator / denominator).toString();
     }
     static BNMultiply(a: string, b: string): string {
-        return BigNumber(a).multipliedBy(BigNumber(b)).toString();
+        return new BN(a).mul(new BN(b)).toString();
     }
     static BNSubtract(a: string, b: string): string {
-        return BigNumber(a).minus(BigNumber(b)).toString();
+        return new BN(a).sub(new BN(b)).toString();
     }
     static BNAdd(a: string, b: string): string {
-        return BigNumber(a).plus(BigNumber(b)).toString();
-    }
-    static BNShift(a: string, b: number): string {
-        return BigNumber(a).shiftedBy(b).toString();
+        return new BN(a).add(new BN(b)).toString();
     }
 
     // Number operations

--- a/src/module/sdk/utils/BalanceOperations.ts
+++ b/src/module/sdk/utils/BalanceOperations.ts
@@ -1,33 +1,32 @@
 import { convertNearToYocto, convertYoctoToNear } from "./near.utils";
-const BN = require("bn.js");
+import BigNumber from "bignumber.js";
+import BN from "bn.js";
 
 export class BalanceOperations {
     //Big number operations
     static BNToString(bn: string): string {
-        return new BN(bn).toString();
+        return BigNumber(bn).toString();
     }
     static BNExp(base: number, exponent: number): string {
-        return new BN(base).pow(new BN(exponent)).toString();
+        return new BigNumber(base).pow(BigNumber(exponent)).toString();
     }
     static BNIsBigger(a: string, b: string): boolean {
-        return new BN(a).gt(new BN(b));
+        return BigNumber(a).gt(BigNumber(b));
     }
     static BNIsBiggerOrEqual(a: string, b: string): boolean {
-        return new BN(a).gte(new BN(b));
+        return BigNumber(a).gte(BigNumber(b));
     }
-    static BNDevide(a: string, b: string): string {
-        const numerator = parseFloat(a);
-        const denominator = parseFloat(b);
-        return (numerator / denominator).toString();
+    static BNDivide(a: string, b: string): string {
+        return BigNumber(a).dividedBy(BigNumber(b)).toString();
     }
     static BNMultiply(a: string, b: string): string {
-        return new BN(a).mul(new BN(b)).toString();
+        return BigNumber(a).multipliedBy(BigNumber(b)).toString();
     }
     static BNSubtract(a: string, b: string): string {
-        return new BN(a).sub(new BN(b)).toString();
+        return BigNumber(a).minus(BigNumber(b)).toString();
     }
     static BNAdd(a: string, b: string): string {
-        return new BN(a).add(new BN(b)).toString();
+        return BigNumber(a).plus(BigNumber(b)).toString();
     }
 
     // Number operations
@@ -47,7 +46,7 @@ export class BalanceOperations {
         try {
             const finalA = convertNearToYocto(a.toString());
             const finalB = convertNearToYocto(b.toString());
-            const res = new BN(finalA).add(new BN(finalB));
+            const res = new BN(finalA).add(new BN(finalB)).toString();
             return convertYoctoToNear(res).toString();
         } catch (e) {
             // eslint-disable-next-line no-console
@@ -70,7 +69,7 @@ export class BalanceOperations {
             // 3 near = 3 * 10^24 yoctos
             // 3 * 3 * 10^(24 + 24) = 9 * 10 ^ 48  yoctos
             // 9 * 10^48 yoctos / 1 * 10^24 = 9 * 10^(48 - 24) = 9 * 10^24 near
-            const res = bigRes.div(new BN(convertNearToYocto("1")));
+            const res = bigRes.div(new BN(convertNearToYocto("1"))).toString();
             return convertYoctoToNear(res).toString();
         } catch (e) {
             // eslint-disable-next-line no-console

--- a/src/module/sdk/utils/near.utils.ts
+++ b/src/module/sdk/utils/near.utils.ts
@@ -1,6 +1,7 @@
 import { utils } from "near-api-js";
 import { AccountBalance } from "near-api-js/lib/account";
 import { BalanceOperations } from "./BalanceOperations";
+import BigNumber from "bignumber.js";
 
 /**
  * Convert Near amount to yocto
@@ -93,7 +94,9 @@ export function parseBlockTimestamp(blockTimestamp: string): string {
  * @returns Return number version of token amount
  */
 export function formatTokenAmount(amount: string, decimals: string, precision?: number): string {
-    return BalanceOperations.BNShift(amount, -(precision ?? Number(decimals)));
+    return BigNumber(amount)
+        .shiftedBy(-(precision ?? Number(decimals)))
+        .toString();
 }
 
 /**

--- a/src/module/sdk/utils/near.utils.ts
+++ b/src/module/sdk/utils/near.utils.ts
@@ -94,7 +94,7 @@ export function parseBlockTimestamp(blockTimestamp: string): string {
  */
 export function formatTokenAmount(amount: string, decimals: string, precision?: number): string {
     const denominator = BalanceOperations.BNExp(10, parseInt(decimals, 10));
-    return BalanceOperations.BNDevide(amount, denominator).slice(0, precision ?? Number(decimals));
+    return BalanceOperations.BNDivide(amount, denominator).slice(0, precision ?? Number(decimals));
 }
 
 /**

--- a/src/module/sdk/utils/near.utils.ts
+++ b/src/module/sdk/utils/near.utils.ts
@@ -93,8 +93,7 @@ export function parseBlockTimestamp(blockTimestamp: string): string {
  * @returns Return number version of token amount
  */
 export function formatTokenAmount(amount: string, decimals: string, precision?: number): string {
-    const denominator = BalanceOperations.BNExp(10, parseInt(decimals, 10));
-    return BalanceOperations.BNDivide(amount, denominator).slice(0, precision ?? Number(decimals));
+    return BalanceOperations.BNShift(amount, -(precision ?? Number(decimals)));
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3367,6 +3367,11 @@ bignumber.js@^9.0.2:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
   integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
 
+bignumber.js@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
 bip39-light@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/bip39-light/-/bip39-light-1.0.7.tgz#06a72f251b89389a136d3f177f29b03342adc5ba"


### PR DESCRIPTION
# [TA-2249] Fix token decimals display

## Changes

- Use `parseFloat` instead of `BigInt` in `BNDevide`
