### PR TITLE
[TA-2258] Remove `system` transactions

### DIFF
--- a/src/module/sdk/NearApiService/NearBlocksService.ts
+++ b/src/module/sdk/NearApiService/NearBlocksService.ts
@@ -93,31 +93,33 @@ export class NearBlocksService extends FetchService {
 
         const txs: Action[] = [];
         for (const tx of baseTxs.txns) {
-            const baseTransaction: TransactionWithoutActions = {
-                transactionHash: tx.transaction_hash,
-                includedInBlockHash: tx.included_in_block_hash,
-                blockTimestamp: parseBlockTimestamp(tx.block_timestamp),
-                signerAccountId: tx.predecessor_account_id,
-                nonce: 0,
-                receiverAccountId: tx.receiver_account_id,
-            };
-            for (const [i, action] of tx.actions.entries()) {
-                txs.push({
-                    transaction: baseTransaction,
-                    actionKind: this.parseActionKindApiDto(action.action as TransactionActionKind, tx.receiver_account_id, address),
+            if (tx.predecessor_account_id !== "system") {
+                const baseTransaction: TransactionWithoutActions = {
                     transactionHash: tx.transaction_hash,
-                    indexInTransaction: i,
-                    // codeSha256: "", // For DEPLOY_CONTRACT kind
-                    gas: tx.outcomes_agg.transaction_fee, // For FUNCTION_CALL kind
-                    // deposit: "", // For FUNCTION_CALL, TRANSFER kind
-                    // argsBase64: "", // For FUNCTION_CALL kind
-                    // argsJson: "", // For FUNCTION_CALL kind
-                    methodName: action.method || undefined,
-                    // stake: "", // For STAKE kind
-                    // publicKey: baseTransaction.receiverAccountId, // For STAKE, ADD_KEY, DELETE_KEY kind
-                    // accessKey: "", // For ADD_KEY kind
-                    // beneficiaryId: "", // For DELETE_ACCOUNT kind
-                });
+                    includedInBlockHash: tx.included_in_block_hash,
+                    blockTimestamp: parseBlockTimestamp(tx.block_timestamp),
+                    signerAccountId: tx.predecessor_account_id,
+                    nonce: 0,
+                    receiverAccountId: tx.receiver_account_id,
+                };
+                for (const [i, action] of tx.actions.entries()) {
+                    txs.push({
+                        transaction: baseTransaction,
+                        actionKind: this.parseActionKindApiDto(action.action as TransactionActionKind, tx.receiver_account_id, address),
+                        transactionHash: tx.transaction_hash,
+                        indexInTransaction: i,
+                        // codeSha256: "", // For DEPLOY_CONTRACT kind
+                        gas: tx.outcomes_agg.transaction_fee, // For FUNCTION_CALL kind
+                        // deposit: "", // For FUNCTION_CALL, TRANSFER kind
+                        // argsBase64: "", // For FUNCTION_CALL kind
+                        // argsJson: "", // For FUNCTION_CALL kind
+                        methodName: action.method || undefined,
+                        // stake: "", // For STAKE kind
+                        // publicKey: baseTransaction.receiverAccountId, // For STAKE, ADD_KEY, DELETE_KEY kind
+                        // accessKey: "", // For ADD_KEY kind
+                        // beneficiaryId: "", // For DELETE_ACCOUNT kind
+                    });
+                }
             }
         }
         return txs;

--- a/src/module/sdk/NearApiService/NearBlocksService.ts
+++ b/src/module/sdk/NearApiService/NearBlocksService.ts
@@ -87,7 +87,6 @@ export class NearBlocksService extends FetchService {
         return (await this.getAccountTokens({ address })).tokens.nfts;
     }
 
-    // eslint-disable-next-line  @typescript-eslint/no-unused-vars
     async getRecentActivity({ address }: NearApiServiceParams): Promise<Action[]> {
         const baseTxs = await this.fetch<NearBlocsTransactionResponseDto>(`/account/${address}/txns?page=1&per_page=10&order=desc`);
 


### PR DESCRIPTION
# [TA-2258] Remove `system` transactions

## Changes

- Add an `if` statement to check the `predecessor_account_id` of a transaction in `NearBlocksService` to exclude `system` transactions
