### PR TITLE
[TA-2359] Fix Validator 0 staked amount when it has > 0

### DIFF
--- a/src/module/sdk/NearApiService/NearBlocks/NearBlocksService.ts
+++ b/src/module/sdk/NearApiService/NearBlocks/NearBlocksService.ts
@@ -160,9 +160,7 @@ export class NearBlocksService extends FetchService {
         }
 
         for (const key of Object.keys(validatorAmounts)) {
-            if (validatorAmounts[key] > 0) {
-                deposits.push({ validatorId: key, amount: validatorAmounts[key] });
-            }
+            deposits.push({ validatorId: key, amount: validatorAmounts[key] });
         }
 
         return deposits;

--- a/src/module/sdk/NearSdkService/NearSdkService.ts
+++ b/src/module/sdk/NearSdkService/NearSdkService.ts
@@ -640,6 +640,10 @@ export class NearSDKService {
                 this.getValidatorDataFromId(validatorId, true, amount),
             );
             validators = await Promise.all(validatorsProms);
+            // Remove validators that no longer have any amount in it
+            validators = validators.filter(
+                ({ stakingBalance: sb }) => sb && (sb.staked !== "0" || sb.available !== "0" || sb.pending !== "0"),
+            );
         } catch (e) {
             //eslint-disable-next-line no-console
             console.warn("Error in getCurrentValidators: ", e);


### PR DESCRIPTION
# Fix Validator 0 staked amount when it has > 0 PR

## Issues :1st_place_medal: 

- [Validator 0 staked amount when it has > 0](https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=d5e0adb3750d49028baf853b550c5316&pm=s)

## Changes :hammer_and_wrench: 

- Return all possible validators in API call
- Filter validators with 0 amount in get current validators
