### PR TITLE
Fix SignerRequestModal not scrolling on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ This document logs notable, developer-facing updates to the NEAR Mobile Wallet.
 ### 🐛 Bug Fixes
 
 -   Fix NFTs not being displayed in the APP [fix/nft-not-being-displayed](https://github.com/Peersyst/near-mobile-wallet/pull/537)
+-   Fix SignerRequestModal not scrolling on Android [fix/signer-request-not-scrolling-on-android](https://github.com/Peersyst/near-mobile-wallet/pull/538)

--- a/src/module/signer/components/display/ActionsSlider/ActionsSlider.tsx
+++ b/src/module/signer/components/display/ActionsSlider/ActionsSlider.tsx
@@ -12,7 +12,7 @@ export interface ActionsSliderProps {
 
 const ActionsSlider = ({ actions, ...rest }: ActionsSliderProps) => {
     return (
-        <ActionsSliderRoot gap={0} showPageIndicator={actions.length > 1} style={{ flex: 1 }}>
+        <ActionsSliderRoot onStartShouldSetResponder={() => true} gap={0} showPageIndicator={actions.length > 1} style={{ flex: 1 }}>
             {actions.map(({ type, params }, index) => {
                 const ActionComponent = ActionDetails[type];
                 return <ActionComponent key={index} params={params} {...rest} />;

--- a/src/module/signer/containers/SignerRequestModal/SignerRequestModal.tsx
+++ b/src/module/signer/containers/SignerRequestModal/SignerRequestModal.tsx
@@ -26,7 +26,14 @@ const SignerRequestModal = createModal(({ id, ...modalProps }: SignerModalProps)
     const handleReject = () => rejectRequest(id);
 
     return (
-        <CardSelectModal {...modalProps} title={translate("reviewRequest")} dismissal="close" style={{ height: "95%" }}>
+        <CardSelectModal
+            propagateSwipe
+            swipeable={false}
+            {...modalProps}
+            title={translate("reviewRequest")}
+            dismissal="close"
+            style={{ height: "95%" }}
+        >
             <Skeleton loading={isLoading}>
                 {isSignerRequestError ? (
                     signerRequestError


### PR DESCRIPTION
# Fix SignerRequestModa not scrolling on android

## Motivation 💡

<!--
Describe the problem or motivation behind this pull request
-->

-  When trying to scroll to see multiple actions in the signer request modal it does not work.

## Changes 🛠

<!--
Explain the changes made in this pull request
-->

-   Add a the prop `onStartShouldSetResponder` to the PagerView


