### PR TITLE
Fix: get actions from the kitwallet version of nearblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ This document logs notable, developer-facing updates to the NEAR Mobile Wallet.
 ### 🐛 Bug Fixes
 
 -   Fix NFTs not being displayed in the APP [fix/nft-not-being-displayed](https://github.com/Peersyst/near-mobile-wallet/pull/537)
+-   Get actions from the kitwallet api of NearBlocks [fix/actions-rate-limited](https://github.com/Peersyst/near-mobile-wallet/pull/540)

--- a/src/module/sdk/NearApiService/NearBlocks/NearBlocksService.types.ts
+++ b/src/module/sdk/NearApiService/NearBlocks/NearBlocksService.types.ts
@@ -63,14 +63,47 @@ export interface NearBlocksActivityDto {
     action_index: number;
     signer_id: string;
     receiver_id: string;
-    action_kind: string;
-    args: {
-        gas: number;
-        deposit: string;
-        args_json: object;
-        args_base64: string | null;
-        method_name: string;
-    };
+    action_kind: TransactionActionKind;
+    args: NearBlocksArgs;
+} // Validated
+
+export interface NearBlocksArgs {
+    public_key: string; //
+    access_key?: NearBlocksAccessKey; //
+    deposit?: string; //
+    gas?: number; //
+    args_json?: NearBlocksArgsJson; //
+    args_base64?: string | null; //
+    method_name?: string; //
+    stake?: string;
+    code_sha_256?: string;
+    beneficiary_id?: string;
+}
+
+export interface NearBlocksArgsJson {
+    msg?: string;
+    amount?: string; //
+    receiver_id?: string; //
+    account_id?: string; //
+    new_account_id?: string;
+    new_public_key?: string;
+    registration_only?: boolean; //
+}
+
+export interface NearBlocksAccessKey {
+    nonce: number;
+    permission: NearBlocksPermission;
+}
+
+export interface NearBlocksPermission {
+    permission_kind: string;
+    permission_details: NearBlocksPermissionDetails;
+}
+
+export interface NearBlocksPermissionDetails {
+    allowance?: string | null;
+    receiver_id: string;
+    method_names: string[];
 }
 
 export interface NearBlocksTokenResponseDto {

--- a/src/module/sdk/NearSdkService/NearSdkService.types.ts
+++ b/src/module/sdk/NearSdkService/NearSdkService.types.ts
@@ -202,7 +202,7 @@ export type ActionKind = Exclude<keyof typeof TransactionActionKind, "TRANSFER">
 
 export type TransactionWithoutActions = Omit<Transaction, "transactionActions">;
 
-export type Action = Omit<TransactionAction, "actionKind"> & {
+export type Action = Omit<TransactionAction, "actionKind" | "transactionActions"> & {
     transaction: TransactionWithoutActions;
     actionKind: ActionKind;
 };

--- a/src/module/transaction/query/useGetActions.ts
+++ b/src/module/transaction/query/useGetActions.ts
@@ -2,6 +2,7 @@ import { useQuery } from "react-query";
 import useServiceInstance from "module/wallet/hook/useServiceInstance";
 import Queries from "../../../query/queries";
 import { config } from "config";
+import useSelectedWalletIndex from "module/wallet/hook/useSelectedWalletIndex";
 
 export interface UseGetActionsOptions {
     /**
@@ -11,14 +12,16 @@ export interface UseGetActionsOptions {
 }
 
 const useGetActions = ({ index }: UseGetActionsOptions = {}) => {
+    const selectedWallet = useSelectedWalletIndex();
     const { serviceInstance, index: usedIndex, network, queryEnabled } = useServiceInstance(index);
+
     return useQuery(
         [Queries.ACTIONS, usedIndex, network],
         async () => {
             return await serviceInstance.getRecentActivity();
         },
         {
-            enabled: queryEnabled,
+            enabled: queryEnabled && selectedWallet === usedIndex,
             refetchInterval: config.refetchIntervals.transactions,
         },
     );


### PR DESCRIPTION
Fix: get actions from the kitwallet version of nearblocks