### PR TITLE
Fix `android` backup data bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ This document logs notable, developer-facing updates to the NEAR Mobile Wallet.
 
 -   Document resolved bugs for improved performance and security.
 
+## 1.8.6
+
+### 🐛 Bug Fixes
+
+-   Fix `android` backup data bug
+
+## 1.8.3 - 1.8.5
+
+### 🐛 Bug Fixes
+
+-   Update `eas.json`
+
 ## 1.8.2
 
 ### 🐛 Bug Fixes

--- a/app.config.ts
+++ b/app.config.ts
@@ -5,7 +5,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     name: "NEAR Mobile",
     slug: "NEARMobileWallet",
     owner: "peersyst",
-    version: "1.8.5",
+    version: "1.8.6",
     orientation: "portrait",
     icon: "./assets/images/near-icon.png",
     scheme: "near-mobile-wallet",

--- a/src/config/configs/config.base.json
+++ b/src/config/configs/config.base.json
@@ -1,5 +1,5 @@
 {
-    "appVersion": "1.8.5",
+    "appVersion": "1.8.6",
     "projectName": "near-mobile-wallet",
     "minimumTransactionAmount": 61,
     "mainnetExplorerLink": "https://nearblocks.io",

--- a/src/locale/locales/en/common.json
+++ b/src/locale/locales/en/common.json
@@ -356,5 +356,6 @@
     "removeFavourites": "Remove from favourites",
     "scanQR": "Scan QR",
     "actions": "Actions",
-    "version": "Version"
+    "version": "Version",
+    "contactUs": "Contact us"
 }

--- a/src/locale/locales/en/errors.json
+++ b/src/locale/locales/en/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Error updating app",
     "errorSecurityQuiz": "You have answered one or more questions incorrectly. Please try again later. Remember, this validation is solely for your own security.",
     "tryAgain": "Try again",
-    "errorInWalletBackupQuizTitle": "Error in wallet backup quiz"
+    "errorInWalletBackupQuizTitle": "Error in wallet backup quiz",
+    "somethingWentWrongLoadingTheAppTitle": "Something went wrong loading the app.",
+    "somethingWentWrongLoadingTheAppDescription": "Please, contact us via Telegram pressing the button below."
 }

--- a/src/locale/locales/es/common.json
+++ b/src/locale/locales/es/common.json
@@ -354,5 +354,6 @@
     "add": "Agregar",
     "addToFavourites": "Agregar a favoritos",
     "removeFavourites": "Eliminar de favoritos",
-    "version": "Versión"
+    "version": "Versión",
+    "contactUs": "Contáctanos"
 }

--- a/src/locale/locales/es/errors.json
+++ b/src/locale/locales/es/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Error al actualizar la aplicación",
     "errorSecurityQuiz": "Has respondido incorrectamente una o más preguntas. Inténtalo de nuevo más tarde. Recuerda, esta validación es solo para tu propia seguridad.",
     "tryAgain": "Intentar de nuevo",
-    "errorInWalletBackupQuizTitle": "Error en el quiz de respaldo de la billetera"
+    "errorInWalletBackupQuizTitle": "Error en el quiz de respaldo de la billetera",
+    "somethingWentWrongLoadingTheAppTitle": "Algo salió mal al cargar la aplicación.",
+    "somethingWentWrongLoadingTheAppDescription": "Por favor, contáctanos a través de Telegram presionando el botón de abajo."
 }

--- a/src/locale/locales/fr/common.json
+++ b/src/locale/locales/fr/common.json
@@ -354,5 +354,6 @@
     "add": "Ajouter",
     "addToFavourites": "Ajouter aux favoris",
     "removeFavourites": "Retirer des favoris",
-    "version": "Version"
+    "version": "Version",
+    "contactUs": "Contactez-nous"
 }

--- a/src/locale/locales/fr/errors.json
+++ b/src/locale/locales/fr/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Erreur lors de la mise à jour de l'application",
     "errorSecurityQuiz": "Vous avez mal répondu à une ou plusieurs questions. Veuillez réessayer plus tard. N'oubliez pas, cette validation est uniquement pour votre propre sécurité.",
     "tryAgain": "Réessayer",
-    "errorInWalletBackupQuizTitle": "Erreur dans le quiz de sauvegarde du portefeuille"
+    "errorInWalletBackupQuizTitle": "Erreur dans le quiz de sauvegarde du portefeuille",
+    "somethingWentWrongLoadingTheAppTitle": "Une erreur s'est produite lors du chargement de l'application.",
+    "somethingWentWrongLoadingTheAppDescription": "Veuillez nous contacter via Telegram en appuyant sur le bouton ci-dessous."
 }

--- a/src/locale/locales/id/common.json
+++ b/src/locale/locales/id/common.json
@@ -354,5 +354,6 @@
     "add": "Tambahkan",
     "addToFavourites": "Tambahkan ke favorit",
     "removeFavourites": "Hapus dari favorit",
-    "version": "Versi"
+    "version": "Versi",
+    "contactUs": "Hubungi kami"
 }

--- a/src/locale/locales/id/errors.json
+++ b/src/locale/locales/id/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Kesalahan saat memperbarui aplikasi",
     "errorSecurityQuiz": "Anda telah menjawab satu atau lebih pertanyaan dengan salah. Silakan coba lagi nanti. Ingat, validasi ini hanya untuk keamanan Anda sendiri.",
     "tryAgain": "Coba lagi",
-    "errorInWalletBackupQuizTitle": "Kesalahan dalam kuis cadangan dompet"
+    "errorInWalletBackupQuizTitle": "Kesalahan dalam kuis cadangan dompet",
+    "somethingWentWrongLoadingTheAppTitle": "Ada yang salah saat memuat aplikasi.",
+    "somethingWentWrongLoadingTheAppDescription": "Silakan hubungi kami melalui Telegram dengan menekan tombol di bawah ini."
 }

--- a/src/locale/locales/it/common.json
+++ b/src/locale/locales/it/common.json
@@ -354,5 +354,6 @@
     "add": "Aggiungi",
     "addToFavourites": "Aggiungi ai preferiti",
     "removeFavourites": "Rimuovi dai preferiti",
-    "version": "Versione"
+    "version": "Versione",
+    "contactUs": "Contattaci"
 }

--- a/src/locale/locales/it/errors.json
+++ b/src/locale/locales/it/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Errore durante l'aggiornamento dell'applicazione",
     "errorSecurityQuiz": "Hai risposto in modo errato a una o più domande. Riprova più tardi. Ricorda, questa validazione è solo per la tua sicurezza.",
     "tryAgain": "Riprova",
-    "errorInWalletBackupQuizTitle": "Errore nel quiz di backup del portafoglio"
+    "errorInWalletBackupQuizTitle": "Errore nel quiz di backup del portafoglio",
+    "somethingWentWrongLoadingTheAppTitle": "Si è verificato un errore durante il caricamento dell'app.",
+    "somethingWentWrongLoadingTheAppDescription": "Per favore, contattaci tramite Telegram premendo il pulsante qui sotto."
 }

--- a/src/locale/locales/pt/common.json
+++ b/src/locale/locales/pt/common.json
@@ -354,5 +354,6 @@
     "add": "Adicionar",
     "addToFavourites": "Adicionar aos favoritos",
     "removeFavourites": "Remover dos favoritos",
-    "version": "Versão"
+    "version": "Versão",
+    "contactUs": "Contate-nos"
 }

--- a/src/locale/locales/pt/errors.json
+++ b/src/locale/locales/pt/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Erro ao atualizar o aplicativo",
     "errorSecurityQuiz": "Você respondeu incorretamente a uma ou mais perguntas. Por favor, tente novamente mais tarde. Lembre-se, esta validação é apenas para sua própria segurança.",
     "tryAgain": "Tente novamente",
-    "errorInWalletBackupQuizTitle": "Erro no quiz de backup da carteira"
+    "errorInWalletBackupQuizTitle": "Erro no quiz de backup da carteira",
+    "somethingWentWrongLoadingTheAppTitle": "Algo deu errado ao carregar o aplicativo.",
+    "somethingWentWrongLoadingTheAppDescription": "Por favor, entre em contato conosco via Telegram pressionando o botão abaixo."
 }

--- a/src/locale/locales/ru/common.json
+++ b/src/locale/locales/ru/common.json
@@ -354,5 +354,6 @@
     "add": "Добавить",
     "addToFavourites": "Добавить в избранное",
     "removeFavourites": "Удалить из избранного",
-    "version": "Версия"
+    "version": "Версия",
+    "contactUs": "Свяжитесь с нами"
 }

--- a/src/locale/locales/ru/errors.json
+++ b/src/locale/locales/ru/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Ошибка при обновлении приложения",
     "errorSecurityQuiz": "Вы ответили неправильно на один или несколько вопросов. Попробуйте еще раз позже. Помните, эта проверка предназначена исключительно для вашей безопасности.",
     "tryAgain": "Попробовать снова",
-    "errorInWalletBackupQuizTitle": "Ошибка в викторине резервного копирования кошелька"
+    "errorInWalletBackupQuizTitle": "Ошибка в викторине резервного копирования кошелька",
+    "somethingWentWrongLoadingTheAppTitle": "Что-то пошло не так при загрузке приложения.",
+    "somethingWentWrongLoadingTheAppDescription": "Пожалуйста, свяжитесь с нами через Telegram, нажав кнопку ниже."
 }

--- a/src/locale/locales/sw/common.json
+++ b/src/locale/locales/sw/common.json
@@ -354,5 +354,6 @@
     "add": "Ongeza",
     "addToFavourites": "Ongeza kwenye vipendwa",
     "removeFavourites": "Ondoa kwenye vipendwa",
-    "version": "Toleo"
+    "version": "Toleo",
+    "contactUs": "Wasiliana nasi"
 }

--- a/src/locale/locales/sw/errors.json
+++ b/src/locale/locales/sw/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Hitilafu wakati wa kusasisha programu",
     "errorSecurityQuiz": "Umejibu swali moja au zaidi vibaya. Tafadhali jaribu tena baadaye. Kumbuka, uthibitishaji huu ni kwa usalama wako mwenyewe.",
     "tryAgain": "Jaribu tena",
-    "errorInWalletBackupQuizTitle": "Hitilafu kwenye jaribio la chelezo la pochi"
+    "errorInWalletBackupQuizTitle": "Hitilafu kwenye jaribio la chelezo la pochi",
+    "somethingWentWrongLoadingTheAppTitle": "Kuna kitu kimeenda vibaya wakati wa kupakia programu.",
+    "somethingWentWrongLoadingTheAppDescription": "Tafadhali, wasiliana nasi kupitia Telegram kwa kubonyeza kitufe hapa chini."
 }

--- a/src/locale/locales/uk/common.json
+++ b/src/locale/locales/uk/common.json
@@ -354,5 +354,6 @@
     "add": "Додати",
     "addToFavourites": "Додати до вибраного",
     "removeFavourites": "Видалити з вибраного",
-    "version": "Версія"
+    "version": "Версія",
+    "contactUs": "Зв'яжіться з нами"
 }

--- a/src/locale/locales/uk/errors.json
+++ b/src/locale/locales/uk/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Помилка під час оновлення додатка",
     "errorSecurityQuiz": "Ви відповіли неправильно на одне або більше питань. Будь ласка, спробуйте пізніше. Пам'ятайте, ця перевірка тільки для вашої безпеки.",
     "tryAgain": "Спробуйте ще раз",
-    "errorInWalletBackupQuizTitle": "Помилка у вікторині резервного копіювання гаманця"
+    "errorInWalletBackupQuizTitle": "Помилка у вікторині резервного копіювання гаманця",
+    "somethingWentWrongLoadingTheAppTitle": "Щось пішло не так під час завантаження додатку.",
+    "somethingWentWrongLoadingTheAppDescription": "Будь ласка, зв'яжіться з нами через Telegram, натиснувши кнопку нижче."
 }

--- a/src/locale/locales/vi/common.json
+++ b/src/locale/locales/vi/common.json
@@ -354,5 +354,6 @@
     "add": "Thêm",
     "addToFavourites": "Thêm vào mục yêu thích",
     "removeFavourites": "Xóa khỏi mục yêu thích",
-    "version": "Phiên bản"
+    "version": "Phiên bản",
+    "contactUs": "Liên hệ với chúng tôi"
 }

--- a/src/locale/locales/vi/errors.json
+++ b/src/locale/locales/vi/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "Lỗi khi cập nhật ứng dụng",
     "errorSecurityQuiz": "Bạn đã trả lời sai một hoặc nhiều câu hỏi. Vui lòng thử lại sau. Hãy nhớ, việc xác thực này chỉ nhằm mục đích bảo mật cho riêng bạn.",
     "tryAgain": "Thử lại",
-    "errorInWalletBackupQuizTitle": "Lỗi trong câu đố sao lưu ví"
+    "errorInWalletBackupQuizTitle": "Lỗi trong câu đố sao lưu ví",
+    "somethingWentWrongLoadingTheAppTitle": "Đã xảy ra lỗi khi tải ứng dụng.",
+    "somethingWentWrongLoadingTheAppDescription": "Vui lòng liên hệ với chúng tôi qua Telegram bằng cách nhấn nút bên dưới."
 }

--- a/src/locale/locales/zh-CN/common.json
+++ b/src/locale/locales/zh-CN/common.json
@@ -354,5 +354,6 @@
     "add": "添加",
     "addToFavourites": "添加到收藏夹",
     "removeFavourites": "从收藏夹中删除",
-    "version": "版本"
+    "version": "版本",
+    "contactUs": "联系我们"
 }

--- a/src/locale/locales/zh-CN/errors.json
+++ b/src/locale/locales/zh-CN/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "更新应用程序时出错",
     "errorSecurityQuiz": "您回答了一个或多个问题错误。请稍后再试。请记住，此验证仅用于您的安全。",
     "tryAgain": "再试一次",
-    "errorInWalletBackupQuizTitle": "钱包备份测验中的错误"
+    "errorInWalletBackupQuizTitle": "钱包备份测验中的错误",
+    "somethingWentWrongLoadingTheAppTitle": "加载应用程序时出现错误。",
+    "somethingWentWrongLoadingTheAppDescription": "请通过点击下方按钮通过 Telegram 联系我们。"
 }

--- a/src/locale/locales/zh-TW/common.json
+++ b/src/locale/locales/zh-TW/common.json
@@ -354,5 +354,6 @@
     "add": "添加",
     "addToFavourites": "添加到收藏夾",
     "removeFavourites": "從收藏夾中移除",
-    "version": "版本"
+    "version": "版本",
+    "contactUs": "聯繫我們"
 }

--- a/src/locale/locales/zh-TW/errors.json
+++ b/src/locale/locales/zh-TW/errors.json
@@ -54,5 +54,7 @@
     "updateAppError": "更新應用程式時出錯",
     "errorSecurityQuiz": "您回答了一個或多個問題錯誤。請稍後再試。請記住，此驗證僅用於您的安全。",
     "tryAgain": "再試一次",
-    "errorInWalletBackupQuizTitle": "錢包備份測驗中的錯誤"
+    "errorInWalletBackupQuizTitle": "錢包備份測驗中的錯誤",
+    "somethingWentWrongLoadingTheAppTitle": "載入應用程式時發生錯誤。",
+    "somethingWentWrongLoadingTheAppDescription": "請透過點擊下方按鈕通過 Telegram 聯繫我們。"
 }


### PR DESCRIPTION
# Fix `android` backup data bug

## Motivation 💡

- Fix `android` backup data bug freezing the app when reinstalling it.
- https://docs.expo.dev/versions/v52.0.0/sdk/securestore/#android-auto-backup
- https://github.com/expo/expo/issues/23426

## Changes 🛠

- Handle backed up data decryption error in `useLoad` and remove secure storage data to starts fresh.

## Considerations 🤔

## Dependencies 📦

- [Dev](https://github.com/Peersyst/near-mobile-wallet)
