### PR TITLE
Fix balance calculation

### DIFF
--- a/src/module/sdk/NearSdkService/NearSdkService.ts
+++ b/src/module/sdk/NearSdkService/NearSdkService.ts
@@ -505,12 +505,16 @@ export class NearSDKService {
             const storageAmountPerByte = protocolConfig.runtime_config.storage_amount_per_byte;
 
             const staked = BigInt(accountBalance.locked);
+            /**
+             * The available balance is the total balance that the user can spend.
+             * https://github.com/near/nearcore/blob/master/runtime/runtime/src/verifier.rs#L186
+             */
             const available = BigInt(accountBalance.amount);
             const stateStaked = BigInt(accountBalance.storage_usage) * BigInt(storageAmountPerByte); // Used for storage
             const total = BigInt(accountBalance.amount) + staked + stateStaked;
 
             return this.convertAccountBalanceToNear({
-                total: total.toString(),
+                total: total.toString(), // Not used
                 stateStaked: stateStaked.toString(),
                 staked: staked.toString(),
                 available: available.toString(),


### PR DESCRIPTION
# Fix balance calculation

## Motivation 💡

- Fix balance calculation when user has only state as its balance.

<!--
Describe the problem or motivation behind this pull request
-->

## Changes

-   Do not use `near-api-js` calculation method and use custom method.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced account balance retrieval now shows a detailed breakdown including total, state-staked, staked, and available funds.
  - Improved calculation methods provide more accurate balance details by incorporating storage usage factors.
- **Bug Fixes**
  - Error handling improved to ensure default values are returned in case of exceptions during balance retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->