### PR TITLE
Add NEAR Intents dApp metadata to Config

### DIFF
--- a/src/config/configs/config.base.json
+++ b/src/config/configs/config.base.json
@@ -88,13 +88,12 @@
                 "contractId": "intents.near"
             },
             {
-              "name": "RHEA Finance",
-              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
-              "url": "https://rhea.finance/",
-              "logoUrl":
-                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
-              "tags": ["dex","lending"],
-              "contractId": "boostfarm.ref-labs.near"
+                "name": "RHEA Finance",
+                "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+                "url": "https://rhea.finance/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+                "tag": "dex",
+                "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",

--- a/src/config/configs/config.base.json
+++ b/src/config/configs/config.base.json
@@ -75,17 +75,26 @@
                 "name": "NEAR",
                 "description": "The OS for an Open Web.",
                 "url": "https://near.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/ea2d8bdc-c47a-423c-933a-b242a6e525cf.jpg",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
             {
-                "name": "Ref Finance",
-                "description": "Ref Finance is a community-led, multi-purpose Decentralized Finance (DeFi) platform built on NEAR Protocol.",
-                "url": "https://app.ref.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/525f6f41-b6a1-46bd-94ef-23f64f09b4a2.png",
+                "name": "NEAR Intents",
+                "description": "NEAR Intents: Fast cross-chain trades, no bridging needed. Swap assets effortlessly with Chain Abstraction.",
+                "url": "https://app.near-intents.org/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/85b7e8c9-30d6-4344-a024-d4c3adeb5e5b.png",
                 "tag": "dex",
-                "contractId": "asset-manager.orderly-network.near"
+                "contractId": "intents.near"
+            },
+            {
+              "name": "RHEA Finance",
+              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+              "url": "https://rhea.finance/",
+              "logoUrl":
+                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+              "tags": ["dex","lending"],
+              "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",
@@ -94,14 +103,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/647377ad-d8a3-4497-9ca6-2a41154664bc.png",
                 "tag": "liquidStaking",
                 "contractId": "meta-pool.near"
-            },
-            {
-                "name": "Burrow",
-                "description": "Supply and borrow interest-bearing assets (stNEAR, stETH, aUSDC) on NEAR Protocol.",
-                "url": "https://app.burrow.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/fde1877b-7c77-4073-b46e-eabfe91bcedf.webp",
-                "tag": "lending",
-                "contractId": "contract.main.burrow.near"
             },
             {
                 "name": "Popula",
@@ -115,7 +116,7 @@
                 "name": "near.social",
                 "description": "A BOS component NEAR on chain twitter-like social network.",
                 "url": "https://near.social",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/de53e1e8-42e2-46f3-9c9c-6981616bbfb5.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
@@ -163,7 +164,7 @@
                 "name": "PotLock",
                 "description": "AI-PGF @ai_pgf + THE OPEN FUNDING STACK Where anyone can put funding on the table. Discover impact projects, donate directly, & participate in funding rounds.",
                 "url": "https://app.potlock.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/da270c50-9911-429c-ada3-437f9503707d.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "funding",
                 "contractId": "social.near"
             },
@@ -182,14 +183,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/e8fc4be0-ffb3-458a-bab0-ee059ee38372.JPG",
                 "tag": "bridge",
                 "contractId": "contract.portalbridge.near"
-            },
-            {
-                "name": "TKN",
-                "description": "Near chain's exclusive Token Launch Platform,  Token will automatically whitelist on @finance_ref.",
-                "url": "https://tkn.homes/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/5739203a-8e24-43a5-974a-e5f08975f330.JPG",
-                "tag": "launchpad",
-                "contractId": "tknx.near"
             },
             {
                 "name": "MITTE",

--- a/src/config/configs/config.dev.json
+++ b/src/config/configs/config.dev.json
@@ -115,13 +115,12 @@
                 "contractId": "intents.near"
             },
             {
-              "name": "RHEA Finance",
-              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
-              "url": "https://rhea.finance/",
-              "logoUrl":
-                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
-              "tags": ["dex","lending"],
-              "contractId": "boostfarm.ref-labs.near"
+                "name": "RHEA Finance",
+                "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+                "url": "https://rhea.finance/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+                "tag": "dex",
+                "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",

--- a/src/config/configs/config.dev.json
+++ b/src/config/configs/config.dev.json
@@ -102,17 +102,26 @@
                 "name": "NEAR",
                 "description": "The OS for an Open Web.",
                 "url": "https://near.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/ea2d8bdc-c47a-423c-933a-b242a6e525cf.jpg",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
             {
-                "name": "Ref Finance",
-                "description": "Ref Finance is a community-led, multi-purpose Decentralized Finance (DeFi) platform built on NEAR Protocol.",
-                "url": "https://app.ref.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/525f6f41-b6a1-46bd-94ef-23f64f09b4a2.png",
+                "name": "NEAR Intents",
+                "description": "NEAR Intents: Fast cross-chain trades, no bridging needed. Swap assets effortlessly with Chain Abstraction.",
+                "url": "https://app.near-intents.org/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/85b7e8c9-30d6-4344-a024-d4c3adeb5e5b.png",
                 "tag": "dex",
-                "contractId": "asset-manager.orderly-network.near"
+                "contractId": "intents.near"
+            },
+            {
+              "name": "RHEA Finance",
+              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+              "url": "https://rhea.finance/",
+              "logoUrl":
+                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+              "tags": ["dex","lending"],
+              "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",
@@ -121,14 +130,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/647377ad-d8a3-4497-9ca6-2a41154664bc.png",
                 "tag": "liquidStaking",
                 "contractId": "meta-pool.near"
-            },
-            {
-                "name": "Burrow",
-                "description": "Supply and borrow interest-bearing assets (stNEAR, stETH, aUSDC) on NEAR Protocol.",
-                "url": "https://app.burrow.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/fde1877b-7c77-4073-b46e-eabfe91bcedf.webp",
-                "tag": "lending",
-                "contractId": "contract.main.burrow.near"
             },
             {
                 "name": "Popula",
@@ -142,7 +143,7 @@
                 "name": "near.social",
                 "description": "A BOS component NEAR on chain twitter-like social network.",
                 "url": "https://near.social",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/de53e1e8-42e2-46f3-9c9c-6981616bbfb5.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
@@ -190,7 +191,7 @@
                 "name": "PotLock",
                 "description": "AI-PGF @ai_pgf + THE OPEN FUNDING STACK Where anyone can put funding on the table. Discover impact projects, donate directly, & participate in funding rounds.",
                 "url": "https://app.potlock.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/da270c50-9911-429c-ada3-437f9503707d.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "funding",
                 "contractId": "social.near"
             },
@@ -209,14 +210,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/e8fc4be0-ffb3-458a-bab0-ee059ee38372.JPG",
                 "tag": "bridge",
                 "contractId": "contract.portalbridge.near"
-            },
-            {
-                "name": "TKN",
-                "description": "Near chain's exclusive Token Launch Platform,  Token will automatically whitelist on @finance_ref.",
-                "url": "https://tkn.homes/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/5739203a-8e24-43a5-974a-e5f08975f330.JPG",
-                "tag": "launchpad",
-                "contractId": "tknx.near"
             },
             {
                 "name": "MITTE",

--- a/src/config/configs/config.prod.json
+++ b/src/config/configs/config.prod.json
@@ -115,13 +115,12 @@
                 "contractId": "intents.near"
             },
             {
-              "name": "RHEA Finance",
-              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
-              "url": "https://rhea.finance/",
-              "logoUrl":
-                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
-              "tags": ["dex","lending"],
-              "contractId": "boostfarm.ref-labs.near"
+                "name": "RHEA Finance",
+                "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+                "url": "https://rhea.finance/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+                "tag": "dex",
+                "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",

--- a/src/config/configs/config.prod.json
+++ b/src/config/configs/config.prod.json
@@ -102,17 +102,26 @@
                 "name": "NEAR",
                 "description": "The OS for an Open Web.",
                 "url": "https://near.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/ea2d8bdc-c47a-423c-933a-b242a6e525cf.jpg",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
             {
-                "name": "Ref Finance",
-                "description": "Ref Finance is a community-led, multi-purpose Decentralized Finance (DeFi) platform built on NEAR Protocol.",
-                "url": "https://app.ref.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/525f6f41-b6a1-46bd-94ef-23f64f09b4a2.png",
+                "name": "NEAR Intents",
+                "description": "NEAR Intents: Fast cross-chain trades, no bridging needed. Swap assets effortlessly with Chain Abstraction.",
+                "url": "https://app.near-intents.org/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/85b7e8c9-30d6-4344-a024-d4c3adeb5e5b.png",
                 "tag": "dex",
-                "contractId": "asset-manager.orderly-network.near"
+                "contractId": "intents.near"
+            },
+            {
+              "name": "RHEA Finance",
+              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+              "url": "https://rhea.finance/",
+              "logoUrl":
+                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+              "tags": ["dex","lending"],
+              "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",
@@ -121,14 +130,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/647377ad-d8a3-4497-9ca6-2a41154664bc.png",
                 "tag": "liquidStaking",
                 "contractId": "meta-pool.near"
-            },
-            {
-                "name": "Burrow",
-                "description": "Supply and borrow interest-bearing assets (stNEAR, stETH, aUSDC) on NEAR Protocol.",
-                "url": "https://app.burrow.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/fde1877b-7c77-4073-b46e-eabfe91bcedf.webp",
-                "tag": "lending",
-                "contractId": "contract.main.burrow.near"
             },
             {
                 "name": "Popula",
@@ -142,7 +143,7 @@
                 "name": "near.social",
                 "description": "A BOS component NEAR on chain twitter-like social network.",
                 "url": "https://near.social",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/de53e1e8-42e2-46f3-9c9c-6981616bbfb5.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
@@ -190,7 +191,7 @@
                 "name": "PotLock",
                 "description": "AI-PGF @ai_pgf + THE OPEN FUNDING STACK Where anyone can put funding on the table. Discover impact projects, donate directly, & participate in funding rounds.",
                 "url": "https://app.potlock.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/da270c50-9911-429c-ada3-437f9503707d.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "funding",
                 "contractId": "social.near"
             },
@@ -209,14 +210,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/e8fc4be0-ffb3-458a-bab0-ee059ee38372.JPG",
                 "tag": "bridge",
                 "contractId": "contract.portalbridge.near"
-            },
-            {
-                "name": "TKN",
-                "description": "Near chain's exclusive Token Launch Platform,  Token will automatically whitelist on @finance_ref.",
-                "url": "https://tkn.homes/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/5739203a-8e24-43a5-974a-e5f08975f330.JPG",
-                "tag": "launchpad",
-                "contractId": "tknx.near"
             },
             {
                 "name": "MITTE",

--- a/src/config/configs/config.staging.json
+++ b/src/config/configs/config.staging.json
@@ -115,13 +115,12 @@
                 "contractId": "intents.near"
             },
             {
-              "name": "RHEA Finance",
-              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
-              "url": "https://rhea.finance/",
-              "logoUrl":
-                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
-              "tags": ["dex","lending"],
-              "contractId": "boostfarm.ref-labs.near"
+                "name": "RHEA Finance",
+                "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+                "url": "https://rhea.finance/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+                "tag": "dex",
+                "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",

--- a/src/config/configs/config.staging.json
+++ b/src/config/configs/config.staging.json
@@ -102,17 +102,26 @@
                 "name": "NEAR",
                 "description": "The OS for an Open Web.",
                 "url": "https://near.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/ea2d8bdc-c47a-423c-933a-b242a6e525cf.jpg",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
             {
-                "name": "Ref Finance",
-                "description": "Ref Finance is a community-led, multi-purpose Decentralized Finance (DeFi) platform built on NEAR Protocol.",
-                "url": "https://app.ref.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/525f6f41-b6a1-46bd-94ef-23f64f09b4a2.png",
+                "name": "NEAR Intents",
+                "description": "NEAR Intents: Fast cross-chain trades, no bridging needed. Swap assets effortlessly with Chain Abstraction.",
+                "url": "https://app.near-intents.org/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/85b7e8c9-30d6-4344-a024-d4c3adeb5e5b.png",
                 "tag": "dex",
-                "contractId": "asset-manager.orderly-network.near"
+                "contractId": "intents.near"
+            },
+            {
+              "name": "RHEA Finance",
+              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+              "url": "https://rhea.finance/",
+              "logoUrl":
+                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+              "tags": ["dex","lending"],
+              "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",
@@ -121,14 +130,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/647377ad-d8a3-4497-9ca6-2a41154664bc.png",
                 "tag": "liquidStaking",
                 "contractId": "meta-pool.near"
-            },
-            {
-                "name": "Burrow",
-                "description": "Supply and borrow interest-bearing assets (stNEAR, stETH, aUSDC) on NEAR Protocol.",
-                "url": "https://app.burrow.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/fde1877b-7c77-4073-b46e-eabfe91bcedf.webp",
-                "tag": "lending",
-                "contractId": "contract.main.burrow.near"
             },
             {
                 "name": "Popula",
@@ -142,7 +143,7 @@
                 "name": "near.social",
                 "description": "A BOS component NEAR on chain twitter-like social network.",
                 "url": "https://near.social",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/de53e1e8-42e2-46f3-9c9c-6981616bbfb5.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
@@ -190,7 +191,7 @@
                 "name": "PotLock",
                 "description": "AI-PGF @ai_pgf + THE OPEN FUNDING STACK Where anyone can put funding on the table. Discover impact projects, donate directly, & participate in funding rounds.",
                 "url": "https://app.potlock.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/da270c50-9911-429c-ada3-437f9503707d.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "funding",
                 "contractId": "social.near"
             },
@@ -209,14 +210,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/e8fc4be0-ffb3-458a-bab0-ee059ee38372.JPG",
                 "tag": "bridge",
                 "contractId": "contract.portalbridge.near"
-            },
-            {
-                "name": "TKN",
-                "description": "Near chain's exclusive Token Launch Platform,  Token will automatically whitelist on @finance_ref.",
-                "url": "https://tkn.homes/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/5739203a-8e24-43a5-974a-e5f08975f330.JPG",
-                "tag": "launchpad",
-                "contractId": "tknx.near"
             },
             {
                 "name": "MITTE",

--- a/src/config/configs/config.test.json
+++ b/src/config/configs/config.test.json
@@ -101,17 +101,26 @@
                 "name": "NEAR",
                 "description": "The OS for an Open Web.",
                 "url": "https://near.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/ea2d8bdc-c47a-423c-933a-b242a6e525cf.jpg",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
             {
-                "name": "Ref Finance",
-                "description": "Ref Finance is a community-led, multi-purpose Decentralized Finance (DeFi) platform built on NEAR Protocol.",
-                "url": "https://app.ref.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/525f6f41-b6a1-46bd-94ef-23f64f09b4a2.png",
+                "name": "NEAR Intents",
+                "description": "NEAR Intents: Fast cross-chain trades, no bridging needed. Swap assets effortlessly with Chain Abstraction.",
+                "url": "https://app.near-intents.org/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/85b7e8c9-30d6-4344-a024-d4c3adeb5e5b.png",
                 "tag": "dex",
-                "contractId": "asset-manager.orderly-network.near"
+                "contractId": "intents.near"
+            },
+            {
+              "name": "RHEA Finance",
+              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+              "url": "https://rhea.finance/",
+              "logoUrl":
+                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+              "tags": ["dex","lending"],
+              "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",
@@ -120,14 +129,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/647377ad-d8a3-4497-9ca6-2a41154664bc.png",
                 "tag": "liquidStaking",
                 "contractId": "meta-pool.near"
-            },
-            {
-                "name": "Burrow",
-                "description": "Supply and borrow interest-bearing assets (stNEAR, stETH, aUSDC) on NEAR Protocol.",
-                "url": "https://app.burrow.finance/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/fde1877b-7c77-4073-b46e-eabfe91bcedf.webp",
-                "tag": "lending",
-                "contractId": "contract.main.burrow.near"
             },
             {
                 "name": "Popula",
@@ -141,7 +142,7 @@
                 "name": "near.social",
                 "description": "A BOS component NEAR on chain twitter-like social network.",
                 "url": "https://near.social",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/de53e1e8-42e2-46f3-9c9c-6981616bbfb5.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "social",
                 "contractId": "social.near"
             },
@@ -189,7 +190,7 @@
                 "name": "PotLock",
                 "description": "AI-PGF @ai_pgf + THE OPEN FUNDING STACK Where anyone can put funding on the table. Discover impact projects, donate directly, & participate in funding rounds.",
                 "url": "https://app.potlock.org/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/da270c50-9911-429c-ada3-437f9503707d.JPG",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/77974b8e-51f4-4a06-b914-bdd21ce990ca.png",
                 "tag": "funding",
                 "contractId": "social.near"
             },
@@ -208,14 +209,6 @@
                 "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/e8fc4be0-ffb3-458a-bab0-ee059ee38372.JPG",
                 "tag": "bridge",
                 "contractId": "contract.portalbridge.near"
-            },
-            {
-                "name": "TKN",
-                "description": "Near chain's exclusive Token Launch Platform,  Token will automatically whitelist on @finance_ref.",
-                "url": "https://tkn.homes/",
-                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/5739203a-8e24-43a5-974a-e5f08975f330.JPG",
-                "tag": "launchpad",
-                "contractId": "tknx.near"
             },
             {
                 "name": "MITTE",

--- a/src/config/configs/config.test.json
+++ b/src/config/configs/config.test.json
@@ -114,13 +114,12 @@
                 "contractId": "intents.near"
             },
             {
-              "name": "RHEA Finance",
-              "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
-              "url": "https://rhea.finance/",
-              "logoUrl":
-                "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
-              "tags": ["dex","lending"],
-              "contractId": "boostfarm.ref-labs.near"
+                "name": "RHEA Finance",
+                "description": "Rhea Finance merges Ref Finance (top DEX) and Burrow Finance (top Lending Protocol) to create a next-gen abstracted liquidity solution covering Bitcoin, NEAR, and all other blue-chip assets.",
+                "url": "https://rhea.finance/",
+                "logoUrl": "https://peersyst-public-production.s3.eu-west-1.amazonaws.com/81a0b625-47e5-4da4-a3f9-c50589fdf247.jpg",
+                "tag": "dex",
+                "contractId": "boostfarm.ref-labs.near"
             },
             {
                 "name": "Meta Pool",


### PR DESCRIPTION
# Add NEAR Intents dApp metadata to Config

## Motivation 💡

Add NEAR Intents metadata information to config so dApp image shows at connected sites. (dApp image from explorer website is set at [near-dapps-website repo](https://github.com/Peersyst/near-dapps-website) and dApp image shown at transaction request is set by the dApp at request.)

## Changes 🛠

-   Add NEAR Intents dApp metadata ✨
-   Delete TKN dApp (No longer available.) 
-   Delete REF and Burrow dApps, now RHEA Finance
-   Add RHEA Finance dApp to config ✨
-   Change image for dApps using social.near login so displayed image at connected sites is social.near as it is the corresponding key contract.

## Considerations 🤔

-   NEARProtocol dApp and PotLock app will show with near.social img at connected sites because they use social.near contract ⚠️
-   Support dApp img identification by contract and url so https://near.org and https://app.potlock.org/ have their own image at connected sites.
-   Remove dApp list from near-mobile-repo to near-dapps-website for dapp list updates without the need of an app release.

## Dependencies 📦

<!--
Provide links to any branches or repositories this pull request depends on
-->

-   [Main](https://github.com/Peersyst/near-mobile-wallet)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The entry for "RHEA Finance" in the recommended dApps list has been updated to simplify its tagging structure.
  
- **Chores**
  - Outdated dApp recommendations have been removed to streamline the discovery experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->